### PR TITLE
Fix acc test for datasource of network

### DIFF
--- a/ecl/data_source_ecl_network_network_v2.go
+++ b/ecl/data_source_ecl_network_network_v2.go
@@ -78,18 +78,11 @@ func dataSourceNetworkNetworkV2Read(d *schema.ResourceData, meta interface{}) er
 
 	var listOpts networks.ListOptsBuilder
 
-	var status string
-	if v, ok := d.GetOk("status"); ok {
-		status = v.(string)
-	}
-
 	listOpts = networks.ListOpts{
 		Description: d.Get("description").(string),
 		ID:          d.Get("network_id").(string),
 		Name:        d.Get("name").(string),
 		Plane:       d.Get("plane").(string),
-		Status:      status,
-		TenantID:    d.Get("tenant_id").(string),
 	}
 
 	pages, err := networks.List(networkClient, listOpts).AllPages()

--- a/ecl/data_source_ecl_network_network_v2.go
+++ b/ecl/data_source_ecl_network_network_v2.go
@@ -52,7 +52,6 @@ func dataSourceNetworkNetworkV2() *schema.Resource {
 			},
 			"status": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"subnets": &schema.Schema{
@@ -66,7 +65,6 @@ func dataSourceNetworkNetworkV2() *schema.Resource {
 			},
 			"tenant_id": &schema.Schema{
 				Type:        schema.TypeString,
-				Optional:    true,
 				Computed:    true,
 				Description: descriptions["tenant_id"],
 			},

--- a/ecl/data_source_ecl_network_network_v2_test.go
+++ b/ecl/data_source_ecl_network_network_v2_test.go
@@ -152,6 +152,10 @@ func testAccNetworkV2NetworkDataSourceName(networkName, networkDescription strin
 		}`, testAccNetworkV2NetworkDataSourceNetwork(networkName, networkDescription))
 }
 
+// 1. Firstly, this test case creates two network which has different plane, "data" and "storage".
+//    These two networks have same but random name which is given as argument of this function.
+// 2. Afterward, this case try to extract network by using above "random name" and specified plane,
+//    so that Terraform can extract only one network as data source.
 func testAccNetworkV2NetworkDataSourcePlane(networkName, networkDescription string) string {
 	return fmt.Sprintf(`
 		%s

--- a/website/docs/d/network_network_v2.html.markdown
+++ b/website/docs/d/network_network_v2.html.markdown
@@ -35,11 +35,6 @@ data "ecl_network_network_v2" "network" {
   A Neutron client is needed to retrieve networks ids. If omitted, the
   `region` argument of the provider is used.
 
-* `status` - (Optional) The status of the network.
-
-* `tenant_id` - (Optional) The owner of the network.
-
-
 ## Attributes Reference
 
 `id` is set to the ID of the found network. In addition, the following attributes


### PR DESCRIPTION
In current implementation of network datasource test,
test is sometimes failed due to
existence of network which has same condition.
  (Like status is ACTIVE as well, tenant_id is same, like that)

So this pull request changes followings.

- remove status, tenant_id from argument of datasource
- remove relevant tests to the above changes
- remove them from argument section of corresponding document