### PR TITLE
Rinto/ni 182 implement internet service datasource

### DIFF
--- a/ecl/data_source_ecl_network_gateway_interface_v2_test.go
+++ b/ecl/data_source_ecl_network_gateway_interface_v2_test.go
@@ -128,8 +128,8 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
 
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-	description = "test_internet_gateway"
-	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+    description = "test_internet_gateway"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 

--- a/ecl/data_source_ecl_network_gateway_interface_v2_test.go
+++ b/ecl/data_source_ecl_network_gateway_interface_v2_test.go
@@ -122,10 +122,14 @@ resource "ecl_network_subnet_v2" "subnet_1" {
     network_id = "${ecl_network_network_v2.network_1.id}"
 }
 
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-    description = "test_internet_gateway"
-    internet_service_id = "%s"
+	description = "test_internet_gateway"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -143,7 +147,6 @@ resource "ecl_network_gateway_interface_v2" "gateway_interface_1" {
     depends_on = ["ecl_network_subnet_v2.subnet_1"]
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2GatewayInterfaceDataSourceBasic = fmt.Sprintf(`

--- a/ecl/data_source_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_test.go
@@ -192,15 +192,19 @@ func testAccCheckNetworkV2InternetGatewayDataSourceID(n string) resource.TestChe
 	}
 }
 
+
 var testAccNetworkV2InternetGatewayDataSourceInternetGateway = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
 	name = "Terraform_Test_Internet_Gateway_01"
 	description = "test_internet_gateway"
-	internet_service_id = "%s"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
 	qos_option_id = "%s"
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2InternetGatewayDataSourceBasic = fmt.Sprintf(`
@@ -215,11 +219,10 @@ var testAccNetworkV2InternetGatewayDataSourceInternetServiceID = fmt.Sprintf(`
 %s
 
 data "ecl_network_internet_gateway_v2" "internet_gateway_1" {
-	internet_service_id = "%s"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
 }
 `,
-	testAccNetworkV2InternetGatewayDataSourceInternetGateway,
-	OS_INTERNET_SERVICE_ID)
+	testAccNetworkV2InternetGatewayDataSourceInternetGateway)
 
 var testAccNetworkV2InternetGatewayDataSourceQoSOptionID = fmt.Sprintf(`
 %s

--- a/ecl/data_source_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_test.go
@@ -36,6 +36,7 @@ func TestMockedAccNetworkV2InternetGatewayDataSourceBasic(t *testing.T) {
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetBasic)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingCreate)
@@ -120,6 +121,7 @@ func TestMockedAccNetworkV2InternetGatewayDataSourceTestQueries(t *testing.T) {
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetBasic)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingCreate)
@@ -191,7 +193,6 @@ func testAccCheckNetworkV2InternetGatewayDataSourceID(n string) resource.TestChe
 		return nil
 	}
 }
-
 
 var testAccNetworkV2InternetGatewayDataSourceInternetGateway = fmt.Sprintf(`
 data "ecl_network_internet_service_v2" "internet_service_1" {
@@ -280,7 +281,7 @@ response:
                 {
                     "description": "test_internet_gateway",
                     "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                    "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
+                    "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
                     "name": "Terraform_Test_Internet_Gateway_01",
                     "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                     "status": "ACTIVE",

--- a/ecl/data_source_ecl_network_internet_service_v2.go
+++ b/ecl/data_source_ecl_network_internet_service_v2.go
@@ -1,0 +1,109 @@
+package ecl
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/nttcom/eclcloud/ecl/network/v2/internet_services"
+)
+
+func dataSourceNetworkInternetServiceV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkInternetServiceV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"internet_service_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"minimal_submask_length": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceNetworkInternetServiceV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkClient, err := config.networkV2Client(GetRegion(d, config))
+
+	listOpts := internet_services.ListOpts{}
+
+	if v, ok := d.GetOk("description"); ok {
+		listOpts.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("internet_service_id"); ok {
+		listOpts.ID = v.(string)
+	}
+
+	if v, ok := d.GetOk("minimal_submask_length"); ok {
+		listOpts.MinimalSubmaskLength = v.(int)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = v.(string)
+	}
+
+	if v, ok := d.GetOk("zone"); ok {
+		listOpts.Zone = v.(string)
+	}
+
+	pages, err := internet_services.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve internet_services: %s", err)
+	}
+
+	allInternetServices, err := internet_services.ExtractInternetServices(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract internet_services: %s", err)
+	}
+
+	if len(allInternetServices) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allInternetServices) > 1 {
+		return fmt.Errorf("Your query returned more than one result." +
+			" Please try a more specific search criteria")
+	}
+
+	internet_service := allInternetServices[0]
+
+	log.Printf("[DEBUG] Retrieved InternetService %s: %+v", internet_service.ID, internet_service)
+	d.SetId(internet_service.ID)
+
+	d.Set("description", internet_service.Description)
+	d.Set("minimal_submask_length", internet_service.MinimalSubmaskLength)
+	d.Set("name", internet_service.Name)
+	d.Set("zone", internet_service.Zone)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/ecl/data_source_ecl_network_internet_service_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_test.go
@@ -6,9 +6,37 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestAccNetworkV2InternetServiceDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckInternetService(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_network_internet_service_v2.internet_service_1", "name", "Internet-Service-01"),
+				),
+			},
+		},
+	})
+}
+
+func TestMockedAccNetworkV2InternetServiceDataSourceBasic(t *testing.T) {
+
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
+
+	mc.StartServer(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckInternetService(t) },
 		Providers: testAccProviders,
@@ -64,6 +92,58 @@ func TestAccNetworkV2InternetServiceDataSourceTestQueries(t *testing.T) {
 	})
 }
 
+func TestMockedAccNetworkV2InternetServiceDataSourceTestQueries(t *testing.T) {
+
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListIDQuery)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListDescriptionQuery)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListMinimalSubmaskLengthQuery)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListZoneQuery)
+
+	mc.StartServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckInternetService(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceMinimalSubmaskLength,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceZone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckNetworkV2InternetServiceDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -89,10 +169,9 @@ func testAccReturnMinimalSubmaskLength(region string) int {
 	return minimal_submask_length
 }
 
-
 var testAccNetworkV2InternetServiceDataSourceBasic = fmt.Sprintf(`
 data "ecl_network_internet_service_v2" "internet_service_1" {
-	name = "Internet-Service-01"
+    name = "Internet-Service-01"
 }
 `)
 
@@ -101,7 +180,7 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
   internet_service_id = "%s"
 }
 `,
-OS_INTERNET_SERVICE_ID)
+	OS_INTERNET_SERVICE_ID)
 
 var testAccNetworkV2InternetServiceDataSourceName = fmt.Sprintf(`
 data "ecl_network_internet_service_v2" "internet_service_1" {
@@ -110,7 +189,7 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
 `)
 var testAccNetworkV2InternetServiceDataSourceDescription = fmt.Sprintf(`
 data "ecl_network_internet_service_v2" "internet_service_1" {
-	description = ""
+    description = ""
 }
 `)
 
@@ -119,11 +198,121 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
   minimal_submask_length = %d
 }
 `,
-testAccReturnMinimalSubmaskLength(OS_REGION_NAME))
+	testAccReturnMinimalSubmaskLength(OS_REGION_NAME))
 
 var testAccNetworkV2InternetServiceDataSourceZone = fmt.Sprintf(`
 data "ecl_network_internet_service_v2" "internet_service_1" {
   zone = "%s"
 }
 `,
-OS_INTERNET_SERVICE_ZONE_NAME)
+	OS_INTERNET_SERVICE_ZONE_NAME)
+
+var testMockNetworkV2InternetServiceListNameQuery = `
+request:
+    method: GET
+    Query:
+      name:
+        - 
+response: 
+    code: 200
+    body: >
+        {
+            "internet_services": [
+                {
+                    "description": "Internet-Service-01",
+                    "id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "minimal_submask_length": 26,
+                    "name": "Internet-Service-01",
+                    "zone": "jp1-zone1"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetServiceListIDQuery = `
+request:
+    method: GET
+    Query:
+      id:
+        - a7791c79-19b0-4eb6-9a8f-ea739b44e8d5
+response: 
+    code: 200
+    body: >
+        {
+            "internet_services": [
+                {
+                    "description": "Internet-Service-01",
+                    "id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "minimal_submask_length": 26,
+                    "name": "Internet-Service-01",
+                    "zone": "jp1-zone1"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetServiceListDescriptionQuery = `
+request:
+    method: GET
+    Query:
+      decsription:
+        - Internet-Service-01
+response: 
+    code: 200
+    body: >
+        {
+            "internet_services": [
+                {
+                    "description": "Internet-Service-01",
+                    "id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "minimal_submask_length": 26,
+                    "name": "Internet-Service-01",
+                    "zone": "jp1-zone1"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetServiceListMinimalSubmaskLengthQuery = `
+request:
+    method: GET
+    Query:
+      minimal_submask_length:
+        - 26
+response: 
+    code: 200
+    body: >
+        {
+            "internet_services": [
+                {
+                    "description": "Internet-Service-01",
+                    "id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "minimal_submask_length": 26,
+                    "name": "Internet-Service-01",
+                    "zone": "jp1-zone1"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetServiceListZoneQuery = `
+request:
+    method: GET
+    Query:
+      zone:
+        - jp1-zone1
+response: 
+    code: 200
+    body: >
+        {
+            "internet_services": [
+                {
+                    "description": "Internet-Service-01",
+                    "id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "minimal_submask_length": 26,
+                    "name": "Internet-Service-01",
+                    "zone": "jp1-zone1"
+                }
+            ]
+        }
+`

--- a/ecl/data_source_ecl_network_internet_service_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_test.go
@@ -1,0 +1,129 @@
+package ecl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNetworkV2InternetServiceDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckInternetService(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_network_internet_service_v2.internet_service_1", "name", "Internet-Service-01"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkV2InternetServiceDataSourceTestQueries(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckInternetService(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceMinimalSubmaskLength,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetServiceDataSourceZone,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkV2InternetServiceDataSourceID("data.ecl_network_internet_service_v2.internet_service_1"),
+				),
+			},
+		},
+	})
+}
+
+
+func testAccCheckNetworkV2InternetServiceDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find internet service data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Internet service data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccReturnMinimalSubmaskLength(region string) int {
+	minimal_submask_length := 26
+	if region == "lab4ec" {
+		minimal_submask_length = 28
+	}
+
+	return minimal_submask_length
+}
+
+
+var testAccNetworkV2InternetServiceDataSourceBasic = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+`)
+
+var testAccNetworkV2InternetServiceDataSourceID = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+  internet_service_id = "%s"
+}
+`,
+OS_INTERNET_SERVICE_ID)
+
+var testAccNetworkV2InternetServiceDataSourceName = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+  name = "Internet-Service-01"
+}
+`)
+var testAccNetworkV2InternetServiceDataSourceDescription = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	description = ""
+}
+`)
+
+var testAccNetworkV2InternetServiceDataSourceMinimalSubmaskLength = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+  minimal_submask_length = %d
+}
+`,
+testAccReturnMinimalSubmaskLength(OS_REGION_NAME))
+
+var testAccNetworkV2InternetServiceDataSourceZone = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+  zone = "%s"
+}
+`,
+OS_INTERNET_SERVICE_ZONE_NAME)

--- a/ecl/data_source_ecl_network_internet_service_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_test.go
@@ -212,7 +212,7 @@ request:
     method: GET
     Query:
       name:
-        - 
+        - Internet-Service-01
 response: 
     code: 200
     body: >

--- a/ecl/data_source_ecl_network_public_ip_v2_test.go
+++ b/ecl/data_source_ecl_network_public_ip_v2_test.go
@@ -92,10 +92,14 @@ func testAccCheckNetworkV2PublicIPDataSourceID(n string) resource.TestCheckFunc 
 }
 
 var testAccNetworkV2PublicIPDataSourcePublicIP = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
 	name = "Terraform_Test_Internet_Gateway_01"
 	description = "test_internet_gateway"
-	internet_service_id = "%s"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
 	qos_option_id = "%s"
 }
 
@@ -106,7 +110,6 @@ resource "ecl_network_public_ip_v2" "public_ip_1" {
 	submask_length = 32
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2PublicIPDataSourceBasic = fmt.Sprintf(`

--- a/ecl/data_source_ecl_network_static_route_v2_test.go
+++ b/ecl/data_source_ecl_network_static_route_v2_test.go
@@ -110,10 +110,14 @@ resource "ecl_network_subnet_v2" "subnet_1" {
     network_id = "${ecl_network_network_v2.network_1.id}"
 }
 
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
     description = "test_internet_gateway"
-    internet_service_id = "%s"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -149,7 +153,6 @@ resource "ecl_network_static_route_v2" "static_route_1" {
 				  "ecl_network_public_ip_v2.public_ip_1"]
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2StaticRouteDataSourceBasic = fmt.Sprintf(`

--- a/ecl/import_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/import_ecl_network_internet_gateway_v2_test.go
@@ -37,6 +37,7 @@ func TestMockedAccNetworkV2InternetGatewayImportBasic(t *testing.T) {
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetBasic)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingCreate)

--- a/ecl/provider.go
+++ b/ecl/provider.go
@@ -191,6 +191,7 @@ func Provider() terraform.ResourceProvider {
 			"ecl_network_common_function_gateway_v2": dataSourceNetworkCommonFunctionGatewayV2(),
 			"ecl_network_gateway_interface_v2":       dataSourceNetworkGatewayInterfaceV2(),
 			"ecl_network_internet_gateway_v2":        dataSourceNetworkInternetGatewayV2(),
+			"ecl_network_internet_service_v2":        dataSourceNetworkInternetServiceV2(),
 			"ecl_network_network_v2":                 dataSourceNetworkNetworkV2(),
 			"ecl_network_port_v2":                    dataSourceNetworkPortV2(),
 			"ecl_network_public_ip_v2":               dataSourceNetworkPublicIPV2(),

--- a/ecl/provider_test.go
+++ b/ecl/provider_test.go
@@ -31,6 +31,7 @@ var (
 	OS_IMAGE_ID                              = os.Getenv("OS_IMAGE_ID")
 	OS_IMAGE_NAME                            = os.Getenv("OS_IMAGE_NAME")
 	OS_INTERNET_SERVICE_ID                   = os.Getenv("OS_INTERNET_SERVICE_ID")
+	OS_INTERNET_SERVICE_ZONE_NAME            = os.Getenv("OS_INTERNET_SERVICE_ZONE_NAME")
 	OS_LB_ENVIRONMENT                        = os.Getenv("OS_LB_ENVIRONMENT")
 	OS_MAGNUM_FLAVOR                         = os.Getenv("OS_MAGNUM_FLAVOR")
 	OS_NETWORK_ID                            = os.Getenv("OS_NETWORK_ID")
@@ -235,9 +236,9 @@ func testAccPreCheckGatewayInterface(t *testing.T) {
 func testAccPreCheckInternetGateway(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 
-	if OS_INTERNET_SERVICE_ID == "" {
-		t.Fatal("OS_INTERNET_SERVICE_ID must be set for acceptance tests")
-	}
+	//if OS_INTERNET_SERVICE_ID == "" {
+	//	t.Fatal("OS_INTERNET_SERVICE_ID must be set for acceptance tests")
+	//}
 	if OS_QOS_OPTION_ID_10M == "" {
 		t.Fatal("OS_QOS_OPTION_ID_10M must be set for acceptance tests")
 	}
@@ -245,6 +246,20 @@ func testAccPreCheckInternetGateway(t *testing.T) {
 		t.Fatal("OS_QOS_OPTION_ID_100M must be set for acceptance tests")
 	}
 
+}
+
+func testAccPreCheckInternetService(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_REGION_NAME == "" {
+		t.Skip("Skipping test because OS_REGION_NAME is not set")
+	}
+	if OS_INTERNET_SERVICE_ID == "" {
+		t.Fatal("OS_INTERNET_SERVICE_ID must be set for acceptance tests")
+	}
+	if OS_INTERNET_SERVICE_ZONE_NAME == "" {
+		t.Fatal("OS_INTERNET_SERVICE_ZONE_NAME must be set for acceptance tests")
+	}
 }
 
 func testAccPreCheckPublicIP(t *testing.T) {

--- a/ecl/provider_test.go
+++ b/ecl/provider_test.go
@@ -236,9 +236,6 @@ func testAccPreCheckGatewayInterface(t *testing.T) {
 func testAccPreCheckInternetGateway(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 
-	//if OS_INTERNET_SERVICE_ID == "" {
-	//	t.Fatal("OS_INTERNET_SERVICE_ID must be set for acceptance tests")
-	//}
 	if OS_QOS_OPTION_ID_10M == "" {
 		t.Fatal("OS_QOS_OPTION_ID_10M must be set for acceptance tests")
 	}

--- a/ecl/resource_ecl_network_gateway_interface_v2_test.go
+++ b/ecl/resource_ecl_network_gateway_interface_v2_test.go
@@ -127,10 +127,14 @@ resource "ecl_network_subnet_v2" "subnet_1" {
     network_id = "${ecl_network_network_v2.network_1.id}"
 }
 
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-    description = "test_internet_gateway"
-    internet_service_id = "%s"
+	description = "test_internet_gateway"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -148,7 +152,6 @@ resource "ecl_network_gateway_interface_v2" "gateway_interface_1" {
     depends_on = ["ecl_network_subnet_v2.subnet_1"]
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2GatewayInterfaceUpdate = fmt.Sprintf(`
@@ -164,10 +167,14 @@ resource "ecl_network_subnet_v2" "subnet_1" {
     network_id = "${ecl_network_network_v2.network_1.id}"
 }
 
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-    description = "test_internet_gateway"
-    internet_service_id = "%s"
+	description = "test_internet_gateway"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -186,7 +193,6 @@ resource "ecl_network_gateway_interface_v2" "gateway_interface_1" {
     depends_on = ["ecl_network_subnet_v2.subnet_1"]
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M,
 	stringMaxLength,
 	stringMaxLength)
@@ -203,11 +209,15 @@ resource "ecl_network_subnet_v2" "subnet_1" {
 	no_gateway = true
 	network_id = "${ecl_network_network_v2.network_1.id}"
 }
-	
+
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
 	name = "Terraform_Test_Internet_Gateway_01"
 	description = "test_internet_gateway"
-	internet_service_id = "%s"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
 	qos_option_id = "%s"
 }
 	
@@ -226,7 +236,6 @@ resource "ecl_network_gateway_interface_v2" "gateway_interface_1" {
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2GatewayInterfaceMultiGateway = fmt.Sprintf(`
@@ -241,11 +250,15 @@ resource "ecl_network_subnet_v2" "subnet_1" {
 	no_gateway = true
 	network_id = "${ecl_network_network_v2.network_1.id}"
 }
-	
+
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
 	name = "Terraform_Test_Internet_Gateway_01"
 	description = "test_internet_gateway"
-	internet_service_id = "%s"
+	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
 	qos_option_id = "%s"
 }
 	
@@ -264,5 +277,4 @@ resource "ecl_network_gateway_interface_v2" "gateway_interface_1" {
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)

--- a/ecl/resource_ecl_network_gateway_interface_v2_test.go
+++ b/ecl/resource_ecl_network_gateway_interface_v2_test.go
@@ -133,8 +133,8 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
 
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-	description = "test_internet_gateway"
-	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+    description = "test_internet_gateway"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -173,8 +173,8 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
 
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-	description = "test_internet_gateway"
-	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+    description = "test_internet_gateway"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 

--- a/ecl/resource_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/resource_ecl_network_internet_gateway_v2_test.go
@@ -143,38 +143,47 @@ func testAccCheckNetworkV2InternetGatewayExists(n string, internet_gateway *inte
 }
 
 var testAccNetworkV2InternetGatewayBasic = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
     description = "test_internet_gateway"
-    internet_service_id = "%s"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2InternetGatewayUpdate = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "%s",
     description = "%s",
-    internet_service_id = "%s"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 `,
 	stringMaxLength,
 	stringMaxLength,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_100M)
 
 var testAccNetworkV2InternetGatewayUpdate2 = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "",
     description = "",
-    internet_service_id = "%s"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testMockNetworkV2InternetGatewayPost = `

--- a/ecl/resource_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/resource_ecl_network_internet_gateway_v2_test.go
@@ -55,14 +55,18 @@ func TestMockedAccNetworkV2InternetGatewayBasic(t *testing.T) {
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetBasic)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingCreate)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingUpdate)
+	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingUpdate1)
+	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingUpdate2)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingDelete)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetUpdated)
+	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetUpdated1)
+	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetUpdated2)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetDeleted)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayPut)
+	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayPut1)
+	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayPut2)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayDelete)
 
 	mc.StartServer(t)
@@ -82,7 +86,18 @@ func TestMockedAccNetworkV2InternetGatewayBasic(t *testing.T) {
 				Config: testAccNetworkV2InternetGatewayUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"ecl_network_internet_gateway_v2.internet_gateway_1", "description", "test_internet_gateway2"),
+						"ecl_network_internet_gateway_v2.internet_gateway_1", "name", stringMaxLength),
+					resource.TestCheckResourceAttr(
+						"ecl_network_internet_gateway_v2.internet_gateway_1", "description", stringMaxLength),
+				),
+			},
+			resource.TestStep{
+				Config: testAccNetworkV2InternetGatewayUpdate2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ecl_network_internet_gateway_v2.internet_gateway_1", "name", ""),
+					resource.TestCheckResourceAttr(
+						"ecl_network_internet_gateway_v2.internet_gateway_1", "description", ""),
 				),
 			},
 		},
@@ -196,7 +211,7 @@ response:
             "internet_gateway": {
                 "description": "test_internet_gateway",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
                 "name": "Terraform_Test_Internet_Gateway_01",
                 "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                 "status": "PENDING_CREATE",
@@ -216,7 +231,7 @@ response:
             "internet_gateway": {
                 "description": "test_internet_gateway",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
                 "name": "Terraform_Test_Internet_Gateway_01",
                 "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                 "status": "ACTIVE",
@@ -239,7 +254,7 @@ response:
             "internet_gateway": {
                 "description": "test_internet_gateway",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
                 "name": "Terraform_Test_Internet_Gateway_01",
                 "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                 "status": "PENDING_CREATE",
@@ -252,7 +267,7 @@ counter:
     max: 3
 `
 
-var testMockNetworkV2InternetGatewayGetUpdated = `
+var testMockNetworkV2InternetGatewayGetUpdated1 = `
 request:
     method: GET
 response:
@@ -260,22 +275,45 @@ response:
     body: >
         {
             "internet_gateway": {
-                "description": "test_internet_gateway2",
+                "description": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
-                "name": "Terraform_Test_Internet_Gateway_01",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "qos_option_id": "4861fe30-d941-4199-8a20-eef1b2625a92",
+                "status": "ACTIVE",
+                "tenant_id": "01234567890123456789abcdefabcdef"
+            }
+        }
+expectedStatus:
+    - Updated1
+counter:
+    min: 4
+`
+
+var testMockNetworkV2InternetGatewayGetUpdated2 = `
+request:
+    method: GET
+response:
+    code: 200
+    body: >
+        {
+            "internet_gateway": {
+                "description": "",
+                "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                "name": "",
                 "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                 "status": "ACTIVE",
                 "tenant_id": "01234567890123456789abcdefabcdef"
             }
         }
 expectedStatus:
-    - Updated
+    - Updated2
 counter:
     min: 4
 `
 
-var testMockNetworkV2InternetGatewayGetPendingUpdate = `
+var testMockNetworkV2InternetGatewayGetPendingUpdate1 = `
 request:
     method: GET
 response:
@@ -283,17 +321,40 @@ response:
     body: >
         {
             "internet_gateway": {
-                "description": "test_internet_gateway2",
+                "description": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
-                "name": "Terraform_Test_Internet_Gateway_01",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "qos_option_id": "4861fe30-d941-4199-8a20-eef1b2625a92",
+                "status": "PENDING_UPDATE",
+                "tenant_id": "01234567890123456789abcdefabcdef"
+            }
+        }
+expectedStatus:
+    - Updated1
+counter:
+    max: 3
+`
+
+var testMockNetworkV2InternetGatewayGetPendingUpdate2 = `
+request:
+    method: GET
+response:
+    code: 200
+    body: >
+        {
+            "internet_gateway": {
+                "description": "",
+                "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                "name": "",
                 "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                 "status": "PENDING_UPDATE",
                 "tenant_id": "01234567890123456789abcdefabcdef"
             }
         }
 expectedStatus:
-    - Updated
+    - Updated2
 counter:
     max: 3
 `
@@ -319,7 +380,7 @@ response:
             "internet_gateway": {
                 "description": "test_internet_gateway2",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
                 "name": "Terraform_Test_Internet_Gateway_01",
                 "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
                 "status": "PENDING_DELETE",
@@ -332,7 +393,7 @@ counter:
     max: 3
 `
 
-var testMockNetworkV2InternetGatewayPut = `
+var testMockNetworkV2InternetGatewayPut1 = `
 request:
     method: PUT
 response:
@@ -340,18 +401,40 @@ response:
     body: >
         {
             "internet_gateway": {
-                "description": "test_internet_gateway2",
+                "description": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
-                "internet_service_id": "5536154d-9a00-4b11-81fb-b185c9111d90",
-                "name": "Terraform_Test_Internet_Gateway_01",
-                "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "qos_option_id": "4861fe30-d941-4199-8a20-eef1b2625a92",
                 "status": "PENDING_UPDATE",
                 "tenant_id": "dcb2d589c0c646d0bad45c0cf9f90cf1"
             }
         }
 expectedStatus:
     - Created
-newStatus: Updated
+newStatus: Updated1
+`
+
+var testMockNetworkV2InternetGatewayPut2 = `
+request:
+    method: PUT
+response:
+    code: 200
+    body: >
+        {
+            "internet_gateway": {
+                "description": "",
+                "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                "name": "",
+                "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                "status": "PENDING_UPDATE",
+                "tenant_id": "dcb2d589c0c646d0bad45c0cf9f90cf1"
+            }
+        }
+expectedStatus:
+    - Updated1
+newStatus: Updated2
 `
 
 var testMockNetworkV2InternetGatewayDelete = `
@@ -361,6 +444,7 @@ response:
     code: 204
 expectedStatus:
     - Created
-    - Updated
+    - Updated1
+    - Updated2
 newStatus: Deleted
 `

--- a/ecl/resource_ecl_network_public_ip_v2_test.go
+++ b/ecl/resource_ecl_network_public_ip_v2_test.go
@@ -100,10 +100,14 @@ func testAccCheckNetworkV2PublicIPExists(n string, public_ip *public_ips.PublicI
 }
 
 var testAccNetworkV2PublicIPBasic = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
     description = "test_internet_gateway"
-    internet_service_id = "%s"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -114,15 +118,18 @@ resource "ecl_network_public_ip_v2" "public_ip_1" {
     submask_length = 32
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M,
 	"${ecl_network_internet_gateway_v2.internet_gateway_1.id}")
 
 var testAccNetworkV2PublicIPUpdate = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-    description = "test_internet_gateway"
-    internet_service_id = "%s"
+		description = "test_internet_gateway"
+		internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -133,17 +140,20 @@ resource "ecl_network_public_ip_v2" "public_ip_1" {
   submask_length = 32
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M,
 	stringMaxLength,
 	stringMaxLength,
 	"${ecl_network_internet_gateway_v2.internet_gateway_1.id}")
 
 var testAccNetworkV2PublicIPUpdate2 = fmt.Sprintf(`
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-    description = "test_internet_gateway"
-    internet_service_id = "%s"
+		description = "test_internet_gateway"
+		internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -154,6 +164,5 @@ resource "ecl_network_public_ip_v2" "public_ip_1" {
   submask_length = 32
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M,
 	"${ecl_network_internet_gateway_v2.internet_gateway_1.id}")

--- a/ecl/resource_ecl_network_public_ip_v2_test.go
+++ b/ecl/resource_ecl_network_public_ip_v2_test.go
@@ -128,8 +128,8 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
 
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-		description = "test_internet_gateway"
-		internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+	  description = "test_internet_gateway"
+	  internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -152,8 +152,8 @@ data "ecl_network_internet_service_v2" "internet_service_1" {
 
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
-		description = "test_internet_gateway"
-		internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+	  description = "test_internet_gateway"
+	  internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 

--- a/ecl/resource_ecl_network_static_route_v2_test.go
+++ b/ecl/resource_ecl_network_static_route_v2_test.go
@@ -127,10 +127,14 @@ resource "ecl_network_subnet_v2" "subnet_1" {
     network_id = "${ecl_network_network_v2.network_1.id}"
 }
 
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
     name = "Terraform_Test_Internet_Gateway_01"
     description = "test_internet_gateway"
-    internet_service_id = "%s"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
     qos_option_id = "%s"
 }
 
@@ -155,7 +159,6 @@ resource "ecl_network_public_ip_v2" "public_ip_1" {
   submask_length = 32
 }
 `,
-	OS_INTERNET_SERVICE_ID,
 	OS_QOS_OPTION_ID_10M)
 
 var testAccNetworkV2StaticRouteBasic = fmt.Sprintf(`

--- a/website/docs/d/network_internet_service_v2.html.markdown
+++ b/website/docs/d/network_internet_service_v2.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "ecl"
+page_title: "Enterprise Cloud: ecl_network_internet_service_v2"
+sidebar_current: "docs-ecl-datasource-network-internet_service-v2"
+description: |-
+  Get information on an Enterprise Cloud Internet service.
+---
+
+# ecl\_network\_internet\_service\_v2
+
+Use this data source to get the ID and Details of an Enterprise Cloud Internet service.
+
+## Example Usage
+
+```hcl
+data "ecl_network_internet_service_v2" "internet_service_1" {
+	name = "Internet-Service-01"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region in which to obtain the V2 Network client.
+    If omitted, the `region` argument of the provider is used.
+
+* `description` - (Optional) Description of the Internet Service resource.
+
+* `internet_service_id` - (Optional) Unique ID of the Internet Service resource.
+
+* `minimal_submask_length` - (Optional) Don’t allow allocating public IP blocks with shorter mask.
+
+* `name` - (Optional) Name of the Internet Service resource.
+
+* `zone` - (Optional) Name of zone.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+`id` is set to the ID of the found internet service. In addition, the following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `internet_service_id` - See Argument Reference above.
+* `minimal_submask_length` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `zone` - See Argument Reference above.


### PR DESCRIPTION
Implemented Datasource of Internet Service with simple acc tests.
Summary:
    - Add Internet Service Datasource.
    - Change to use Internet Service datasource for acc tests in Internet Gateway, Gateway Interface, Static Route, Public IP.
    - Change some parameters for provider_test.go.
    - Fix mock acc tests of Internet Gateway.