### PR TITLE
Revise mock testing

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,7 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -not -iwholename './.git/*' -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=ecl
+TESTMOCKEDACCS=TestMockedAcc
 
 default: build
 
@@ -15,6 +16,9 @@ test: fmtcheck
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+
+testmockedacc: fmtcheck
+	TF_MOCK=1 TF_ACC=1 go test $(TEST) -v $(TESTARGS) -run=$(TESTMOCKEDACCS) -timeout 120m
 
 vet:
 	@echo "go vet ."

--- a/ecl/data_source_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_test.go
@@ -2,6 +2,7 @@ package ecl
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -31,21 +32,20 @@ func TestAccNetworkV2InternetGatewayDataSourceBasic(t *testing.T) {
 
 func TestMockedAccNetworkV2InternetGatewayDataSourceBasic(t *testing.T) {
 
+	testPrecheckMockEnv(t)
+
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
-	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
-	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetBasic)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingCreate)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingDelete)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetDeleted)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayDelete)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListNameQuery)
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, OS_REGION_NAME, mc.Endpoint())
+	err := mc.Register("keystone", "/v3/auth/tokens", postKeystone)
+	err = testSetupMockInternetGatewayDatasourceBasic(mc)
+	if err != nil {
+		t.Errorf("Failed to setup mock: %s", err)
+	}
 
-	mc.StartServer(t)
+	mc.StartServer()
+	os.Setenv("OS_AUTH_URL", mc.Endpoint()+"v3/")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckInternetGateway(t) },
@@ -116,21 +116,20 @@ func TestAccNetworkV2InternetGatewayDataSourceTestQueries(t *testing.T) {
 
 func TestMockedAccNetworkV2InternetGatewayDataSourceTestQueries(t *testing.T) {
 
+	testPrecheckMockEnv(t)
+
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
-	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
-	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetBasic)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingCreate)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetPendingDelete)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayGetDeleted)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways/", testMockNetworkV2InternetGatewayDelete)
-	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListNameQuery)
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, OS_REGION_NAME, mc.Endpoint())
+	err := mc.Register("keystone", "/v3/auth/tokens", postKeystone)
+	err = testSetupMockInternetGatewayDatasourceTestQueries(mc)
+	if err != nil {
+		t.Errorf("Failed to setup mock: %s", err)
+	}
 
-	mc.StartServer(t)
+	mc.StartServer()
+	os.Setenv("OS_AUTH_URL", mc.Endpoint()+"v3/")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckInternetGateway(t) },
@@ -194,16 +193,43 @@ func testAccCheckNetworkV2InternetGatewayDataSourceID(n string) resource.TestChe
 	}
 }
 
+func testSetupMockInternetGatewayDatasourceBasic(mc *mock.MockController) error {
+	err := testSetupMockInternetGatewayBasic(mc)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListNamequery)
+
+	// latest error match
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func testSetupMockInternetGatewayDatasourceTestQueries(mc *mock.MockController) error {
+	err := testSetupMockInternetGatewayBasic(mc)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListNamequery)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListDescriptionquery)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListIDquery)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListInternetServiceIDquery)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListQoSOptionIDquery)
+	err = mc.Register("internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayListStatusquery)
+
+	// latest error match
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 var testAccNetworkV2InternetGatewayDataSourceInternetGateway = fmt.Sprintf(`
 data "ecl_network_internet_service_v2" "internet_service_1" {
-	name = "Internet-Service-01"
+    name = "Internet-Service-01"
 }
 
 resource "ecl_network_internet_gateway_v2" "internet_gateway_1" {
-	name = "Terraform_Test_Internet_Gateway_01"
-	description = "test_internet_gateway"
-	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
-	qos_option_id = "%s"
+    name = "Terraform_Test_Internet_Gateway_01"
+    description = "test_internet_gateway"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+    qos_option_id = "%s"
 }
 `,
 	OS_QOS_OPTION_ID_10M)
@@ -212,7 +238,7 @@ var testAccNetworkV2InternetGatewayDataSourceBasic = fmt.Sprintf(`
 %s
 
 data "ecl_network_internet_gateway_v2" "internet_gateway_1" {
-	name = "${ecl_network_internet_gateway_v2.internet_gateway_1.name}"
+    name = "${ecl_network_internet_gateway_v2.internet_gateway_1.name}"
 }
 `, testAccNetworkV2InternetGatewayDataSourceInternetGateway)
 
@@ -220,7 +246,7 @@ var testAccNetworkV2InternetGatewayDataSourceInternetServiceID = fmt.Sprintf(`
 %s
 
 data "ecl_network_internet_gateway_v2" "internet_gateway_1" {
-	internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
+    internet_service_id = "${data.ecl_network_internet_service_v2.internet_service_1.id}"
 }
 `,
 	testAccNetworkV2InternetGatewayDataSourceInternetGateway)
@@ -229,7 +255,7 @@ var testAccNetworkV2InternetGatewayDataSourceQoSOptionID = fmt.Sprintf(`
 %s
 
 data "ecl_network_internet_gateway_v2" "internet_gateway_1" {
-	qos_option_id = "%s"
+    qos_option_id = "%s"
 }
 `,
 	testAccNetworkV2InternetGatewayDataSourceInternetGateway,
@@ -247,7 +273,7 @@ var testAccNetworkV2InternetGatewayDataSourceDescription = fmt.Sprintf(`
 %s
 
 data "ecl_network_internet_gateway_v2" "internet_gateway_1" {
-	description = "test_internet_gateway"
+    description = "test_internet_gateway"
 }
 `, testAccNetworkV2InternetGatewayDataSourceInternetGateway)
 
@@ -267,12 +293,132 @@ data "ecl_network_internet_gateway_v2" "internet_gateway_1" {
 }
 `, testAccNetworkV2InternetGatewayDataSourceInternetGateway)
 
-var testMockNetworkV2InternetGatewayListNameQuery = `
+var testMockNetworkV2InternetGatewayListNamequery = `
 request:
     method: GET
-    Query:
+    query:
       name:
         - Terraform_Test_Internet_Gateway_01
+response: 
+    code: 200
+    body: >
+        {
+            "internet_gateways": [
+                {
+                    "description": "test_internet_gateway",
+                    "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                    "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "name": "Terraform_Test_Internet_Gateway_01",
+                    "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                    "status": "ACTIVE",
+                    "tenant_id": "01234567890123456789abcdefabcdef"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetGatewayListDescriptionquery = `
+request:
+    method: GET
+    query:
+      description:
+        - test_internet_gateway
+response: 
+    code: 200
+    body: >
+        {
+            "internet_gateways": [
+                {
+                    "description": "test_internet_gateway",
+                    "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                    "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "name": "Terraform_Test_Internet_Gateway_01",
+                    "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                    "status": "ACTIVE",
+                    "tenant_id": "01234567890123456789abcdefabcdef"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetGatewayListIDquery = `
+request:
+    method: GET
+    query:
+      id:
+        - 3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61
+response: 
+    code: 200
+    body: >
+        {
+            "internet_gateways": [
+                {
+                    "description": "test_internet_gateway",
+                    "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                    "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "name": "Terraform_Test_Internet_Gateway_01",
+                    "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                    "status": "ACTIVE",
+                    "tenant_id": "01234567890123456789abcdefabcdef"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetGatewayListInternetServiceIDquery = `
+request:
+    method: GET
+    query:
+      internet_service_id:
+        - a7791c79-19b0-4eb6-9a8f-ea739b44e8d5
+response: 
+    code: 200
+    body: >
+        {
+            "internet_gateways": [
+                {
+                    "description": "test_internet_gateway",
+                    "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                    "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "name": "Terraform_Test_Internet_Gateway_01",
+                    "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                    "status": "ACTIVE",
+                    "tenant_id": "01234567890123456789abcdefabcdef"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetGatewayListQoSOptionIDquery = `
+request:
+    method: GET
+    query:
+      qos_option_id:
+        - e497bbc3-1127-4490-a51d-93582c40ab40
+response: 
+    code: 200
+    body: >
+        {
+            "internet_gateways": [
+                {
+                    "description": "test_internet_gateway",
+                    "id": "3e71cf00-ddb5-4eb5-9ed0-ed4c481f6d61",
+                    "internet_service_id": "a7791c79-19b0-4eb6-9a8f-ea739b44e8d5",
+                    "name": "Terraform_Test_Internet_Gateway_01",
+                    "qos_option_id": "e497bbc3-1127-4490-a51d-93582c40ab40",
+                    "status": "ACTIVE",
+                    "tenant_id": "01234567890123456789abcdefabcdef"
+                }
+            ]
+        }
+`
+
+var testMockNetworkV2InternetGatewayListStatusquery = `
+request:
+    method: GET
+    query:
+      status:
+        - ACTIVE
 response: 
     code: 200
     body: >

--- a/ecl/fixtures.go
+++ b/ecl/fixtures.go
@@ -17,23 +17,23 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde0",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv2/01234567890123456789abcdefabcdef"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv2/01234567890123456789abcdefabcdef"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde1",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv2/01234567890123456789abcdefabcdef"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv2/01234567890123456789abcdefabcdef"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde2",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv2/01234567890123456789abcdefabcdef"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv2/01234567890123456789abcdefabcdef"
                             }
                         ],
                         "id": "1234567890abcdef1234567890abcde3",
@@ -45,23 +45,23 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde4",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]s"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]s"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde5",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]s"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]s"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde6",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]s"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]s"
                             }
                         ],
                         "id": "1234567890abcdef1234567890abcde7",
@@ -73,23 +73,23 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde8",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv3"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv3"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde9",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv3"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv3"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcdea",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv3"
+                                "region": "%[1]s",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv3"
                             }
                         ],
                         "id": "1234567890abcdef1234567890abcdeb",
@@ -99,23 +99,23 @@ response:
                     {
                         "endpoints":[
                             {
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv2/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv2/01234567890123456789abcdefabcdef",
+                                "region": "%[1]s",
                                 "interface": "public",
                                 "id": "1234567890abcdef1234567890abcdec"
                             },
                             {
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv2/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv2/01234567890123456789abcdefabcdef",
+                                "region": "%[1]s",
                                 "interface": "admin",
                                 "id": "1234567890abcdef1234567890abcded"
                             },
                             {
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv2/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv2/01234567890123456789abcdefabcdef",
+                                "region": "%[1]s",
                                 "interface": "internal",
                                 "id": "1234567890abcdef1234567890abcdee"
                             }
@@ -127,23 +127,23 @@ response:
                     {
                         "endpoints":[
                             {
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv1/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv1/01234567890123456789abcdefabcdef",
+                                "region": "%[1]s",
                                 "interface": "public",
                                 "id": "1234567890abcdef1234567890abcdd0"
                             },
                             {
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv1/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv1/01234567890123456789abcdefabcdef",
+                                "region": "%[1]s",
                                 "interface": "internal",
                                 "id": "1234567890abcdef1234567890abcdd1"
                             },
                             {
-                                "region_id": "RegionOne",
-                                "url": "%[1]sv1/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region_id": "%[1]s",
+                                "url": "%[2]sv1/01234567890123456789abcdefabcdef",
+                                "region": "%[1]s",
                                 "interface": "admin",
                                 "id": "1234567890abcdef1234567890abcdd2"
                             }

--- a/ecl/provider_test.go
+++ b/ecl/provider_test.go
@@ -453,4 +453,19 @@ func envVarFile(varName string) (string, error) {
 	return tmpFile.Name(), nil
 }
 
+func testPrecheckMockEnv(t *testing.T) {
+	if os.Getenv(MockTestEnvVar) == "" {
+		t.Skip(fmt.Sprintf(
+			"Mocked Acceptance tests skipped unless env '%s' set",
+			MockTestEnvVar))
+	}
+
+	if OS_REGION_NAME == "" {
+		t.Skip(fmt.Sprintf(
+			"Mocked Acceptance tests skipped unless env 'OS_REGION_NAME' set"))
+	}
+}
+
+const MockTestEnvVar = "TF_MOCK"
+
 var stringMaxLength = strings.Repeat("a", 255)


### PR DESCRIPTION
This is a PR to revise mock tests.

Diff
- Improvement: implement `make  testmockedacc`
- Bug fix: make enable to mock List API with Query parameter
- Improvement: make mock helper library decouple from Terraform provider
- Bug fix: add mock data for `testMockNetworkV2InternetGatewayListTestQueries`

I'm sorry to send a large PR.
Would you check PR, please?

```
NW7-RINTO-MAC:terraform-provider-ecl nttcom$ source ~/Programs/terraform/mockrc 
NW7-RINTO-MAC:terraform-provider-ecl nttcom$ make testmockedacc
==> Checking that code complies with gofmt requirements...
TF_MOCK=1 TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -run=TestMockedAcc -timeout 120m
?   	github.com/nttcom/terraform-provider-ecl	[no test files]
=== RUN   TestMockedAccNetworkV2InternetGatewayDataSourceBasic
--- PASS: TestMockedAccNetworkV2InternetGatewayDataSourceBasic (68.13s)
=== RUN   TestMockedAccNetworkV2InternetGatewayDataSourceTestQueries
--- PASS: TestMockedAccNetworkV2InternetGatewayDataSourceTestQueries (68.26s)
=== RUN   TestMockedAccNetworkV2InternetServiceDataSourceBasic
--- PASS: TestMockedAccNetworkV2InternetServiceDataSourceBasic (0.04s)
=== RUN   TestMockedAccNetworkV2InternetServiceDataSourceTestQueries
--- PASS: TestMockedAccNetworkV2InternetServiceDataSourceTestQueries (0.11s)
=== RUN   TestMockedAccNetworkV2InternetGatewayImportBasic
--- PASS: TestMockedAccNetworkV2InternetGatewayImportBasic (68.08s)
=== RUN   TestMockedAccNetworkV2InternetGatewayBasic
--- PASS: TestMockedAccNetworkV2InternetGatewayBasic (136.19s)
PASS
ok  	github.com/nttcom/terraform-provider-ecl/ecl	340.833s
?   	github.com/nttcom/terraform-provider-ecl/ecl/clientconfig	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/nttcom/terraform-provider-ecl/ecl/clientconfig/testing	(cached) [no tests to run]
?   	github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock	[no test files]
```