### PR TITLE
Change timeout of testacc-all target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,7 +37,7 @@ testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 testacc-all: fmtcheck
-	TF_ACC=1 go test ./ecl -v -count=1 -timeout 240m -parallel 4
+	TF_ACC=1 go test ./ecl -v -count=1 -timeout 24h -parallel 4
 
 testacc-short: fmtcheck
 	TF_ACC=1 go test ./ecl -v -short -count=1 -timeout 120m -parallel 4


### PR DESCRIPTION
This make target took 15 hours in sg1 region. So it needs to be extended.