### PR TITLE
Change the Availability Zone of Acctest to environment variables

### DIFF
--- a/ecl/data_source_ecl_baremetal_availability_zone_v2_test.go
+++ b/ecl/data_source_ecl_baremetal_availability_zone_v2_test.go
@@ -18,7 +18,7 @@ func TestAccBaremetalV2AvailabilityZoneDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBaremetalV2AvailabilityZoneDataSourceID("data.ecl_baremetal_availability_zone_v2.zone_groupa"),
 					resource.TestCheckResourceAttr(
-						"data.ecl_baremetal_availability_zone_v2.zone_groupa", "zone_name", OS_BAREMETAL_AVAILABLE_ZONE),
+						"data.ecl_baremetal_availability_zone_v2.zone_groupa", "zone_name", OS_BAREMETAL_ZONE),
 				),
 			},
 		},
@@ -45,5 +45,5 @@ data "ecl_baremetal_availability_zone_v2" "zone_groupa" {
   zone_name = "%s"
 }
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )

--- a/ecl/data_source_ecl_baremetal_availability_zone_v2_test.go
+++ b/ecl/data_source_ecl_baremetal_availability_zone_v2_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccBaremetalV2AvailabilityZoneDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckBaremetal(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -18,7 +18,7 @@ func TestAccBaremetalV2AvailabilityZoneDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBaremetalV2AvailabilityZoneDataSourceID("data.ecl_baremetal_availability_zone_v2.zone_groupa"),
 					resource.TestCheckResourceAttr(
-						"data.ecl_baremetal_availability_zone_v2.zone_groupa", "zone_name", "groupa"),
+						"data.ecl_baremetal_availability_zone_v2.zone_groupa", "zone_name", OS_BAREMETAL_AVAILABLE_ZONE),
 				),
 			},
 		},
@@ -40,8 +40,10 @@ func testAccCheckBaremetalV2AvailabilityZoneDataSourceID(n string) resource.Test
 	}
 }
 
-const testAccBaremetalV2AvailabilityZoneDataSourceBasic = `
+var testAccBaremetalV2AvailabilityZoneDataSourceBasic = fmt.Sprintf(`
 data "ecl_baremetal_availability_zone_v2" "zone_groupa" {
-  zone_name = "groupa"
+  zone_name = "%s"
 }
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)

--- a/ecl/provider_test.go
+++ b/ecl/provider_test.go
@@ -20,9 +20,8 @@ var (
 	OS_COMMON_FUNCTION_POOL_ID               = os.Getenv("OS_COMMON_FUNCTION_POOL_ID")
 	OS_DEDICATED_HYPERVISOR_ENVIRONMENT      = os.Getenv("OS_DEDICATED_HYPERVISOR_ENVIRONMENT")
 	OS_DEFAULT_ZONE                          = os.Getenv("OS_DEFAULT_ZONE")
-	OS_BAREMETAL_AVAILABLE_ZONE              = os.Getenv("OS_BAREMETAL_AVAILABLE_ZONE")
-	OS_NOVA_AVAILABLE_ZONE                   = os.Getenv("OS_NOVA_AVAILABLE_ZONE")
-	OS_NOVA_AVAILABLE_ZONE_HA                = os.Getenv("OS_NOVA_AVAILABLE_ZONE_HA")
+	OS_BAREMETAL_ZONE                        = os.Getenv("OS_BAREMETAL_ZONE")
+	OS_COMPUTE_ZONE_HA                       = os.Getenv("OS_COMPUTE_ZONE_HA")
 	OS_INTERNET_SERVICE_ZONE_NAME            = os.Getenv("OS_INTERNET_SERVICE_ZONE_NAME")
 	OS_QOS_OPTION_ID_100M                    = os.Getenv("OS_QOS_OPTION_ID_100M")
 	OS_QOS_OPTION_ID_10M                     = os.Getenv("OS_QOS_OPTION_ID_10M")
@@ -275,16 +274,16 @@ func testAccPreCheckVNA(t *testing.T) {
 	if OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID == "" {
 		t.Fatal("OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID must be set for acceptance tests of virtual network appliance")
 	}
-	if OS_NOVA_AVAILABLE_ZONE == "" {
-		t.Skip("OS_NOVA_AVAILABLE_ZONE must be set for acceptance tests of virtual network appliance")
+	if OS_DEFAULT_ZONE == "" {
+		t.Skip("OS_DEFAULT_ZONE must be set for acceptance tests of virtual network appliance")
 	}
 }
 
 func testAccPreCheckCompute(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 
-	if OS_NOVA_AVAILABLE_ZONE == "" {
-		t.Skip("OS_NOVA_AVAILABLE_ZONE must be set for acceptance tests of compute")
+	if OS_DEFAULT_ZONE == "" {
+		t.Skip("OS_DEFAULT_ZONE must be set for acceptance tests of compute")
 	}
 }
 
@@ -361,11 +360,11 @@ func testAccPreCheckTenantConnection(t *testing.T) {
 	if OS_ACCEPTER_TENANT_ID == "" && OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID == "" {
 		t.Fatal("OS_ACCEPTER_TENANT_ID and OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID must be set for acceptance tests of tenant connection")
 	}
-	if OS_BAREMETAL_AVAILABLE_ZONE == "" {
-		t.Skip("OS_BAREMETAL_AVAILABLE_ZONE must be set for acceptance tests of tenant connection")
+	if OS_BAREMETAL_ZONE == "" {
+		t.Skip("OS_BAREMETAL_ZONE must be set for acceptance tests of tenant connection")
 	}
-	if OS_NOVA_AVAILABLE_ZONE == "" {
-		t.Skip("OS_NOVA_AVAILABLE_ZONE must be set for acceptance tests of tenant connection")
+	if OS_DEFAULT_ZONE == "" {
+		t.Skip("OS_DEFAULT_ZONE must be set for acceptance tests of tenant connection")
 	}
 }
 
@@ -383,8 +382,8 @@ func testAccPreCheckSecurity(t *testing.T) {
 	if OS_TENANT_ID == "" {
 		t.Fatal("OS_TENANT_ID must be set for acceptance tests of security")
 	}
-	if OS_NOVA_AVAILABLE_ZONE == "" || OS_NOVA_AVAILABLE_ZONE_HA == "" {
-		t.Skip("OS_NOVA_AVAILABLE_ZONE and OS_NOVA_AVAILABLE_ZONE_HA must be set for acceptance tests of security")
+	if OS_DEFAULT_ZONE == "" || OS_COMPUTE_ZONE_HA == "" {
+		t.Skip("OS_DEFAULT_ZONE and OS_COMPUTE_ZONE_HA must be set for acceptance tests of security")
 	}
 }
 
@@ -394,16 +393,16 @@ func testAccPreCheckDedicatedHypervisor(t *testing.T) {
 	if OS_DEDICATED_HYPERVISOR_ENVIRONMENT == "" {
 		t.Skip("This environment does not support Dedicated Hypervisor tests. Set OS_DEDICATED_HYPERVISOR_ENVIRONMENT if you want to run Dedicated Hypervisor test")
 	}
-	if OS_BAREMETAL_AVAILABLE_ZONE == "" {
-		t.Skip("OS_BAREMETAL_AVAILABLE_ZONE must be set for acceptance tests of Dedicated Hypervisor")
+	if OS_BAREMETAL_ZONE == "" {
+		t.Skip("OS_BAREMETAL_ZONE must be set for acceptance tests of Dedicated Hypervisor")
 	}
 }
 
 func testAccPreCheckBaremetal(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 
-	if OS_BAREMETAL_AVAILABLE_ZONE == "" {
-		t.Skip("OS_BAREMETAL_AVAILABLE_ZONE must be set for acceptance tests of baremetal")
+	if OS_BAREMETAL_ZONE == "" {
+		t.Skip("OS_BAREMETAL_ZONE must be set for acceptance tests of baremetal")
 	}
 }
 

--- a/ecl/provider_test.go
+++ b/ecl/provider_test.go
@@ -20,6 +20,9 @@ var (
 	OS_COMMON_FUNCTION_POOL_ID               = os.Getenv("OS_COMMON_FUNCTION_POOL_ID")
 	OS_DEDICATED_HYPERVISOR_ENVIRONMENT      = os.Getenv("OS_DEDICATED_HYPERVISOR_ENVIRONMENT")
 	OS_DEFAULT_ZONE                          = os.Getenv("OS_DEFAULT_ZONE")
+	OS_BAREMETAL_AVAILABLE_ZONE              = os.Getenv("OS_BAREMETAL_AVAILABLE_ZONE")
+	OS_NOVA_AVAILABLE_ZONE                   = os.Getenv("OS_NOVA_AVAILABLE_ZONE")
+	OS_NOVA_AVAILABLE_ZONE_HA                = os.Getenv("OS_NOVA_AVAILABLE_ZONE_HA")
 	OS_INTERNET_SERVICE_ZONE_NAME            = os.Getenv("OS_INTERNET_SERVICE_ZONE_NAME")
 	OS_QOS_OPTION_ID_100M                    = os.Getenv("OS_QOS_OPTION_ID_100M")
 	OS_QOS_OPTION_ID_10M                     = os.Getenv("OS_QOS_OPTION_ID_10M")
@@ -272,6 +275,17 @@ func testAccPreCheckVNA(t *testing.T) {
 	if OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID == "" {
 		t.Fatal("OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID must be set for acceptance tests of virtual network appliance")
 	}
+	if OS_NOVA_AVAILABLE_ZONE == "" {
+		t.Skip("OS_NOVA_AVAILABLE_ZONE must be set for acceptance tests of virtual network appliance")
+	}
+}
+
+func testAccPreCheckCompute(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_NOVA_AVAILABLE_ZONE == "" {
+		t.Skip("OS_NOVA_AVAILABLE_ZONE must be set for acceptance tests of compute")
+	}
 }
 
 func testAccPreCheckAdminOnly(t *testing.T) {
@@ -347,6 +361,12 @@ func testAccPreCheckTenantConnection(t *testing.T) {
 	if OS_ACCEPTER_TENANT_ID == "" && OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID == "" {
 		t.Fatal("OS_ACCEPTER_TENANT_ID and OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID must be set for acceptance tests of tenant connection")
 	}
+	if OS_BAREMETAL_AVAILABLE_ZONE == "" {
+		t.Skip("OS_BAREMETAL_AVAILABLE_ZONE must be set for acceptance tests of tenant connection")
+	}
+	if OS_NOVA_AVAILABLE_ZONE == "" {
+		t.Skip("OS_NOVA_AVAILABLE_ZONE must be set for acceptance tests of tenant connection")
+	}
 }
 
 func testAccPreCheckApprovalRequest(t *testing.T) {
@@ -363,6 +383,9 @@ func testAccPreCheckSecurity(t *testing.T) {
 	if OS_TENANT_ID == "" {
 		t.Fatal("OS_TENANT_ID must be set for acceptance tests of security")
 	}
+	if OS_NOVA_AVAILABLE_ZONE == "" || OS_NOVA_AVAILABLE_ZONE_HA == "" {
+		t.Skip("OS_NOVA_AVAILABLE_ZONE and OS_NOVA_AVAILABLE_ZONE_HA must be set for acceptance tests of security")
+	}
 }
 
 func testAccPreCheckDedicatedHypervisor(t *testing.T) {
@@ -370,6 +393,17 @@ func testAccPreCheckDedicatedHypervisor(t *testing.T) {
 
 	if OS_DEDICATED_HYPERVISOR_ENVIRONMENT == "" {
 		t.Skip("This environment does not support Dedicated Hypervisor tests. Set OS_DEDICATED_HYPERVISOR_ENVIRONMENT if you want to run Dedicated Hypervisor test")
+	}
+	if OS_BAREMETAL_AVAILABLE_ZONE == "" {
+		t.Skip("OS_BAREMETAL_AVAILABLE_ZONE must be set for acceptance tests of Dedicated Hypervisor")
+	}
+}
+
+func testAccPreCheckBaremetal(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_BAREMETAL_AVAILABLE_ZONE == "" {
+		t.Skip("OS_BAREMETAL_AVAILABLE_ZONE must be set for acceptance tests of baremetal")
 	}
 }
 

--- a/ecl/resource_ecl_baremetal_server_v2_mock_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_mock_test.go
@@ -34,7 +34,7 @@ func TestMockedBaremetalV2Server_basic(t *testing.T) {
 	mc.StartServer(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckBaremetal(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBaremetalV2ServerDestroy,
 		Steps: []resource.TestStep{
@@ -167,7 +167,7 @@ response:
 newStatus: Created
 `
 
-var testMockBaremetalV2ServerGetAfterCreate = `
+var testMockBaremetalV2ServerGetAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -178,7 +178,7 @@ response:
             "OS-EXT-STS:power_state": "RUNNING",
             "OS-EXT-STS:task_state": "None",
             "OS-EXT-STS:vm_state": "ACTIVE",
-            "OS-EXT-AZ:availability_zone": "zone1-groupa",
+            "OS-EXT-AZ:availability_zone": "%s",
             "created": "2012-09-07T16:56:37Z",
             "flavor": {
                 "id": "05184ba3-00ba-4fbc-b7a2-03b62b884931",
@@ -336,7 +336,9 @@ response:
         }
 expectedStatus:
     - Created
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)
 
 var testMockBaremetalV2ServerDelete = `
 request:

--- a/ecl/resource_ecl_baremetal_server_v2_mock_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_mock_test.go
@@ -141,7 +141,7 @@ resource "ecl_baremetal_server_v2" "server_1" {
     }
 }
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )
 
 var testMockBaremetalV2ServerCreate = `
@@ -339,7 +339,7 @@ response:
 expectedStatus:
     - Created
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )
 
 var testMockBaremetalV2ServerDelete = `

--- a/ecl/resource_ecl_baremetal_server_v2_mock_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_mock_test.go
@@ -68,7 +68,7 @@ func TestMockedBaremetalV2Server_basic(t *testing.T) {
 	})
 }
 
-const testMockBaremetalV2ServerBasic = `
+var testMockBaremetalV2ServerBasic = fmt.Sprintf(`
 resource "ecl_baremetal_server_v2" "server_1" {
     name = "server1"
     image_id = "image_id"
@@ -76,7 +76,7 @@ resource "ecl_baremetal_server_v2" "server_1" {
     image_name = "image_name"
     flavor_name = "flavor_name"
     user_data = "user_data"
-    availability_zone = "zone1"
+    availability_zone = "%s"
     key_pair = "key_pair"
     admin_pass = "aabbccddeeff"
     metadata = {
@@ -140,7 +140,9 @@ resource "ecl_baremetal_server_v2" "server_1" {
         contents = "ZWNobyAiS3VtYSBQZXJzb25hbGl0eSIgPj4gL2hvbWUvYmlnL3BlcnNvbmFsaXR5"
     }
 }
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)
 
 var testMockBaremetalV2ServerCreate = `
 request:

--- a/ecl/resource_ecl_baremetal_server_v2_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_test.go
@@ -17,7 +17,7 @@ func TestAccBaremetalV2Server_basic(t *testing.T) {
 	var server servers.Server
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckBaremetal(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBaremetalV2ServerDestroy,
 		Steps: []resource.TestStep{
@@ -84,7 +84,7 @@ func testAccCheckBaremetalV2ServerExists(n string, server *servers.Server) resou
 	}
 }
 
-const testAccBaremetalV2ServerBasic = `
+var testAccBaremetalV2ServerBasic = fmt.Sprintf(`
 data "ecl_imagestorages_image_v2" "centos" {
     name = "CentOS-7.3-1611_64_baremetal-server_01"
 }
@@ -94,7 +94,7 @@ data "ecl_baremetal_flavor_v2" "gp2" {
 }
 
 data "ecl_baremetal_availability_zone_v2" "groupa" {
-    zone_name = "groupa"
+    zone_name = "%s"
 }
 
 resource "ecl_network_network_v2" "network_1" {
@@ -181,4 +181,6 @@ resource "ecl_baremetal_server_v2" "server_1" {
         contents = "ZWNobyAiS3VtYSBQZXJzb25hbGl0eSIgPj4gL2hvbWUvYmlnL3BlcnNvbmFsaXR5"
     }
 }
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)

--- a/ecl/resource_ecl_baremetal_server_v2_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_test.go
@@ -182,5 +182,5 @@ resource "ecl_baremetal_server_v2" "server_1" {
     }
 }
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )

--- a/ecl/resource_ecl_compute_volume_attach_v2_test.go
+++ b/ecl/resource_ecl_compute_volume_attach_v2_test.go
@@ -17,7 +17,7 @@ func TestAccComputeVolumeV2Attach_basic(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckCompute(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeVolumeV2AttachDestroy,
 		Steps: []resource.TestStep{
@@ -35,7 +35,7 @@ func TestAccComputeVolumeV2Attach_timeout(t *testing.T) {
 	var va volumes.Attachment
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckCompute(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeVolumeV2AttachDestroy,
 		Steps: []resource.TestStep{
@@ -180,13 +180,13 @@ resource "ecl_compute_instance_v2" "instance_1" {
     uuid = "${ecl_network_network_v2.network_1.id}"
   }
   depends_on = ["ecl_network_subnet_v2.subnet_1"]
-  availability_zone = "zone1-groupb"
+  availability_zone = "%s"
 }
 
 resource "ecl_compute_volume_v2" "volume_1" {
   name = "volume_1"
   size = 15
-  availability_zone = "zone1-groupb"
+  availability_zone = "%s"
 }
 
 resource "ecl_compute_volume_attach_v2" "va_1" {
@@ -194,7 +194,11 @@ resource "ecl_compute_volume_attach_v2" "va_1" {
   server_id = "${ecl_compute_instance_v2.instance_1.id}"
   device = "/dev/vdb"
 }
-`, testCreateNetworkForAttachTargetInstance)
+`,
+	testCreateNetworkForAttachTargetInstance,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testAccComputeVolumeV2AttachTimeout = fmt.Sprintf(`
 %s
@@ -207,13 +211,13 @@ resource "ecl_compute_instance_v2" "instance_1" {
     uuid = "${ecl_network_network_v2.network_1.id}"
   }
   depends_on = ["ecl_network_subnet_v2.subnet_1"]
-  availability_zone = "zone1-groupb"
+  availability_zone = "%s"
 }
 
 resource "ecl_compute_volume_v2" "volume_1" {
   name = "volume_1"
   size = 15
-  availability_zone = "zone1-groupb"
+  availability_zone = "%s"
 }
 
 resource "ecl_compute_volume_attach_v2" "va_1" {
@@ -225,4 +229,8 @@ resource "ecl_compute_volume_attach_v2" "va_1" {
     create = "5m"
   }
 }
-`, testCreateNetworkForAttachTargetInstance)
+`,
+	testCreateNetworkForAttachTargetInstance,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)

--- a/ecl/resource_ecl_compute_volume_attach_v2_test.go
+++ b/ecl/resource_ecl_compute_volume_attach_v2_test.go
@@ -196,8 +196,8 @@ resource "ecl_compute_volume_attach_v2" "va_1" {
 }
 `,
 	testCreateNetworkForAttachTargetInstance,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccComputeVolumeV2AttachTimeout = fmt.Sprintf(`
@@ -231,6 +231,6 @@ resource "ecl_compute_volume_attach_v2" "va_1" {
 }
 `,
 	testCreateNetworkForAttachTargetInstance,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
@@ -32,7 +32,7 @@ func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {
 	mc.StartServer(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDedicatedHypervisor(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDedicatedHypervisorV1ServerDestroy,
 		Steps: []resource.TestStep{
@@ -53,7 +53,7 @@ func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "admin_pass", "aabbccddeeff"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "image_ref", "dfd25820-b368-4012-997b-29a6d0cf8518"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "flavor_ref", "a830b61c-3155-4a61-b7ed-c450862845e6"),
-					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "availability_zone", "groupb"),
+					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "availability_zone", OS_BAREMETAL_AVAILABLE_ZONE),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "metadata.k1", "v1"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "metadata.k2", "v2"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "baremetal_server_id", "24ebe7b8-ecfb-4d9f-a66b-c0120534fc90"),
@@ -63,7 +63,7 @@ func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {
 	})
 }
 
-const testMockDedicatedHypervisorV1ServerBasic = `
+var testMockDedicatedHypervisorV1ServerBasic = fmt.Sprintf(`
 resource "ecl_dedicated_hypervisor_server_v1" "server_1" {
     name = "server1"
     description = "ESXi Dedicated Hypervisor"
@@ -82,13 +82,14 @@ resource "ecl_dedicated_hypervisor_server_v1" "server_1" {
     admin_pass = "aabbccddeeff"
     image_ref = "dfd25820-b368-4012-997b-29a6d0cf8518"
     flavor_ref = "a830b61c-3155-4a61-b7ed-c450862845e6"
-    availability_zone = "groupb"
+    availability_zone = "%s"
     metadata = {
         k1 = "v1"
         k2 = "v2"
     }
 }
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE)
 
 var testMockDedicatedHypervisorV1ServerCreate = `
 request:
@@ -115,7 +116,7 @@ response:
 newStatus: Created
 `
 
-var testMockDedicatedHypervisorV1ServerGetAfterCreate = `
+var testMockDedicatedHypervisorV1ServerGetAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -133,7 +134,7 @@ response:
                     "OS-EXT-STS:power_state": "RUNNING",
                     "OS-EXT-STS:task_state": "None",
                     "OS-EXT-STS:vm_state": "ACTIVE",
-                    "OS-EXT-AZ:availability_zone": "groupb",
+                    "OS-EXT-AZ:availability_zone": "%s",
                     "progress": 100,
                     "created": "2019-10-10T04:11:41Z",
                     "flavor": {
@@ -283,7 +284,9 @@ response:
         }
 expectedStatus:
     - Created
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)
 
 var testMockDedicatedHypervisorV1ServerDelete = `
 request:

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
@@ -53,7 +53,7 @@ func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "admin_pass", "aabbccddeeff"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "image_ref", "dfd25820-b368-4012-997b-29a6d0cf8518"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "flavor_ref", "a830b61c-3155-4a61-b7ed-c450862845e6"),
-					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "availability_zone", OS_BAREMETAL_AVAILABLE_ZONE),
+					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "availability_zone", OS_BAREMETAL_ZONE),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "metadata.k1", "v1"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "metadata.k2", "v2"),
 					resource.TestCheckResourceAttr("ecl_dedicated_hypervisor_server_v1.server_1", "baremetal_server_id", "24ebe7b8-ecfb-4d9f-a66b-c0120534fc90"),
@@ -89,7 +89,7 @@ resource "ecl_dedicated_hypervisor_server_v1" "server_1" {
     }
 }
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE)
+	OS_BAREMETAL_ZONE)
 
 var testMockDedicatedHypervisorV1ServerCreate = `
 request:
@@ -285,7 +285,7 @@ response:
 expectedStatus:
     - Created
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )
 
 var testMockDedicatedHypervisorV1ServerDelete = `

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_test.go
@@ -109,7 +109,7 @@ func testAccCheckDedicatedHypervisorV1ServerExists(n string, server *servers.Ser
 	}
 }
 
-const testAccDedicatedHypervisorV1ServerBasic = `
+var testAccDedicatedHypervisorV1ServerBasic = fmt.Sprintf(`
 data "ecl_baremetal_flavor_v2" "gp1" {
     name = "General Purpose 1 v2"
 }
@@ -119,7 +119,7 @@ data "ecl_imagestorages_image_v2" "esxi" {
 }
 
 data "ecl_baremetal_availability_zone_v2" "groupa" {
-    zone_name = "zone1-groupa"
+    zone_name = "%s"
 }
 
 resource "ecl_network_network_v2" "network_1" {
@@ -166,4 +166,6 @@ resource "ecl_dedicated_hypervisor_server_v1" "server_1" {
         k2 = "v2"
     }
 }
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_test.go
@@ -167,5 +167,5 @@ resource "ecl_dedicated_hypervisor_server_v1" "server_1" {
     }
 }
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
@@ -312,7 +312,7 @@ resource "ecl_compute_instance_v2" "instance_1" {
 }
 `
 
-const attachmentBaremetalServer = `
+var attachmentBaremetalServer = fmt.Sprintf(`
 data "ecl_imagestorages_image_v2" "centos" {
     name = "CentOS-7.3-1611_64_baremetal-server_01"
 }
@@ -322,7 +322,7 @@ data "ecl_baremetal_flavor_v2" "gp2" {
 }
 
 data "ecl_baremetal_availability_zone_v2" "groupa" {
-    zone_name = "groupa"
+    zone_name = "%s"
 }
 
 resource "ecl_baremetal_server_v2" "server_1" {
@@ -388,14 +388,16 @@ resource "ecl_baremetal_server_v2" "server_1" {
         contents = "ZWNobyAiS3VtYSBQZXJzb25hbGl0eSIgPj4gL2hvbWUvYmlnL3BlcnNvbmFsaXR5"
     }
 }
-`
+`,
+	OS_BAREMETAL_AVAILABLE_ZONE,
+)
 
 var attachmentVna = fmt.Sprintf(`
 resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.2.1"
-	availability_zone = "zone1_groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_2"]
@@ -409,7 +411,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }
 `,
-	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID)
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
 var testAccProviderConnectivityV2TenantConnectionAttachmentComputeServer = fmt.Sprintf(`
 %s

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
@@ -389,7 +389,7 @@ resource "ecl_baremetal_server_v2" "server_1" {
     }
 }
 `,
-	OS_BAREMETAL_AVAILABLE_ZONE,
+	OS_BAREMETAL_ZONE,
 )
 
 var attachmentVna = fmt.Sprintf(`
@@ -411,7 +411,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
@@ -78,10 +78,10 @@ func TestMockedAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
+						"host_1_az_group", OS_DEFAULT_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
+						"host_2_az_group", OS_COMPUTE_ZONE_HA),
 				),
 			},
 			resource.TestStep{
@@ -100,10 +100,10 @@ func TestMockedAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
+						"host_1_az_group", OS_DEFAULT_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
+						"host_2_az_group", OS_COMPUTE_ZONE_HA),
 				),
 			},
 		},
@@ -234,8 +234,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceHAUpdate = fmt.Sprintf(`
@@ -263,8 +263,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	}
 }`,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceHAUpdateInterface = fmt.Sprintf(`
@@ -357,8 +357,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListDeviceInterfaces = `
@@ -401,8 +401,8 @@ expectedStatus:
     - ""
 newStatus: PreCreate
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListAfterCreate = fmt.Sprintf(`
@@ -439,10 +439,10 @@ expectedStatus:
     - Created
     - Updating
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListDevicesAfterCreate = fmt.Sprintf(`
@@ -477,8 +477,8 @@ expectedStatus:
     - Updated
     - Created
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListDevicesAfterUpdate = fmt.Sprintf(`
@@ -512,8 +512,8 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE_HA,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_COMPUTE_ZONE_HA,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListDeviceInterfacesAfterCreate = `
@@ -664,8 +664,8 @@ response:
 expectedStatus:
     - Deleted
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHACreate = fmt.Sprintf(`
@@ -870,10 +870,10 @@ response:
 expectedStatus:
     - Updated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListAfterInterfaceUpdate = fmt.Sprintf(`
@@ -909,10 +909,10 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAUpdateInterface = fmt.Sprintf(`
@@ -1324,6 +1324,6 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE_HA,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_COMPUTE_ZONE_HA,
+	OS_COMPUTE_ZONE_HA,
 )

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
@@ -18,7 +18,6 @@ const SoIDOfDeleteHA = "FGHA_F2349100C7D24EF3ACD6B9A9F91FD220"
 const ProcessIDOfUpdateInterfaceHA = 85385
 
 const expectedNewHADeviceHostName1 = "CES12085"
-const expectedNewHADeviceHostName2 = "CES12086"
 const expectedNewHADeviceUUID1 = "12768064-e7c9-44d1-b01d-e66f138a278e"
 const expectedNewHADeviceUUID2 = "12768064-e7c9-44d1-b01d-e66f138a278f"
 
@@ -79,10 +78,10 @@ func TestMockedAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", "zone1-groupa"),
+						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", "zone1-groupb"),
+						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
 				),
 			},
 			resource.TestStep{
@@ -101,10 +100,10 @@ func TestMockedAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", "zone1-groupa"),
+						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", "zone1-groupb"),
+						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
 				),
 			},
 		},
@@ -216,8 +215,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "FW_HA"
 	license_kind = "02"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
 
 	ha_link_1 {
 		network_id = "DummyNetwork1"
@@ -235,6 +234,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceHAUpdate = fmt.Sprintf(`
@@ -244,8 +245,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "UTM_HA"
 	license_kind = "08"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
 
 	ha_link_1 {
 		network_id = "DummyNetwork1"
@@ -262,6 +263,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	}
 }`,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceHAUpdateInterface = fmt.Sprintf(`
@@ -272,8 +275,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "FW_HA"
 	license_kind = "02"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
 
 	ha_link_1 {
 		network_id = "DummyNetwork1"
@@ -354,6 +357,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )
 
 var testMockSecurityV1NetworkBasedDeviceHAListDeviceInterfaces = `
@@ -370,7 +375,7 @@ expectedStatus:
     - Created
 `
 
-var testMockSecurityV1NetworkBasedDeviceHAListBeforeCreate = `
+var testMockSecurityV1NetworkBasedDeviceHAListBeforeCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -383,11 +388,11 @@ response:
             "records": 1,
             "rows": [
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
                     "id": 1
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
                     "id": 2
                 }
             ]
@@ -395,9 +400,12 @@ response:
 expectedStatus:
     - ""
 newStatus: PreCreate
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
-var testMockSecurityV1NetworkBasedDeviceHAListAfterCreate = `
+var testMockSecurityV1NetworkBasedDeviceHAListAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -410,19 +418,19 @@ response:
             "records": 1,
             "rows": [
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
                     "id": 1
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
                     "id": 2
                 },
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12085", "FW_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.3", "dummyNetworkID2", "dummySubnetID2", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12085", "FW_HA", "02", "ha", "%s", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.3", "dummyNetworkID2", "dummySubnetID2", "192.168.2.3"],
                     "id": 3
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12086", "FW_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.4", "dummyNetworkID2", "dummySubnetID2", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12086", "FW_HA", "02", "ha", "%s", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.4", "dummyNetworkID2", "dummySubnetID2", "192.168.2.4"],
                     "id": 4
                 }
             ]
@@ -430,9 +438,14 @@ response:
 expectedStatus:
     - Created
     - Updating
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
-var testMockSecurityV1NetworkBasedDeviceHAListDevicesAfterCreate = `
+var testMockSecurityV1NetworkBasedDeviceHAListDevicesAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -444,7 +457,7 @@ response:
                 "msa_device_id": "CES12085",
                 "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278e",
                 "os_server_name": "UTM-CES11878",
-                "os_availability_zone": "zone1-groupb",
+                "os_availability_zone": "%s",
                 "os_admin_username": "jp4_sdp_mss_utm_admin",
                 "msa_device_type": "FW",
                 "os_server_status": "ACTIVE"
@@ -453,7 +466,7 @@ response:
                 "msa_device_id": "CES12086",
                 "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278f",
                 "os_server_name": "WAF-CES11816",
-                "os_availability_zone": "zone1-groupb",
+                "os_availability_zone": "%s",
                 "os_admin_username": "jp4_sdp_mss_utm_admin",
                 "msa_device_type": "WAF",
                 "os_server_status": "ACTIVE"
@@ -463,9 +476,12 @@ response:
 expectedStatus:
     - Updated
     - Created
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
-var testMockSecurityV1NetworkBasedDeviceHAListDevicesAfterUpdate = `
+var testMockSecurityV1NetworkBasedDeviceHAListDevicesAfterUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -477,7 +493,7 @@ response:
                 "msa_device_id": "CES12085",
                 "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278e",
                 "os_server_name": "UTM-CES11878",
-                "os_availability_zone": "zone1-groupb",
+                "os_availability_zone": "%s",
                 "os_admin_username": "jp4_sdp_mss_utm_admin",
                 "msa_device_type": "FW",
                 "os_server_status": "ACTIVE"
@@ -486,7 +502,7 @@ response:
                 "msa_device_id": "CES12086",
                 "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278f",
                 "os_server_name": "WAF-CES11816",
-                "os_availability_zone": "zone1-groupb",
+                "os_availability_zone": "%s",
                 "os_admin_username": "jp4_sdp_mss_utm_admin",
                 "msa_device_type": "WAF",
                 "os_server_status": "ACTIVE"
@@ -495,7 +511,10 @@ response:
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
 var testMockSecurityV1NetworkBasedDeviceHAListDeviceInterfacesAfterCreate = `
 request:
@@ -620,7 +639,7 @@ expectedStatus:
     - InterfaceIsUpdated
 `
 
-var testMockSecurityV1NetworkBasedDeviceHAListAfterDelete = `
+var testMockSecurityV1NetworkBasedDeviceHAListAfterDelete = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -633,18 +652,21 @@ response:
             "records": 1,
             "rows": [
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
                     "id": 1
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
                     "id": 2
                 }
             ]
         }
 expectedStatus:
     - Deleted
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
 var testMockSecurityV1NetworkBasedDeviceHACreate = fmt.Sprintf(`
 request:
@@ -815,7 +837,7 @@ counter:
     min: 4
 `
 
-var testMockSecurityV1NetworkBasedDeviceHAListAfterUpdate = `
+var testMockSecurityV1NetworkBasedDeviceHAListAfterUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -828,28 +850,33 @@ response:
             "records": 4,
             "rows": [
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
                     "id": 1
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
                     "id": 2
                 },
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12085", "UTM_HA", "08", "ha", "zone1-groupa", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.3", "dummyNetworkID2", "dummySubnetID2", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12085", "UTM_HA", "08", "ha", "%s", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.3", "dummyNetworkID2", "dummySubnetID2", "192.168.2.3"],
                     "id": 3
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12086", "UTM_HA", "08", "ha", "zone1-groupb", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.4", "dummyNetworkID2", "dummySubnetID2", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12086", "UTM_HA", "08", "ha", "%s", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.4", "dummyNetworkID2", "dummySubnetID2", "192.168.2.4"],
                     "id": 4
                 }
             ]
         }
 expectedStatus:
     - Updated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
-var testMockSecurityV1NetworkBasedDeviceHAListAfterInterfaceUpdate = `
+var testMockSecurityV1NetworkBasedDeviceHAListAfterInterfaceUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -862,26 +889,31 @@ response:
             "records": 2,
             "rows": [
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12083", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.3", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.3"],
                     "id": 1
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12084", "UTM_HA", "02", "ha", "%s", "jp4_zone1", "56a5f5b0-dceb-47d9-8e75-8e16dc08d83f", "6b3ee9c8-0f28-41ff-a443-a3122cf89f1f", "192.168.1.4", "bfb4dcb7-f8fd-4ae8-9023-9c648e56b455", "085ea95a-a04b-4eb4-bdfc-124445fb5cec", "192.168.2.4"],
                     "id": 2
                 },
                 {
-                    "cell": ["false", "1", "1902F60E", "CES12085", "FW_HA", "02", "ha", "zone1-groupa", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.3", "dummyNetworkID2", "dummySubnetID2", "192.168.2.3"],
+                    "cell": ["false", "1", "1902F60E", "CES12085", "FW_HA", "02", "ha", "%s", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.3", "dummyNetworkID2", "dummySubnetID2", "192.168.2.3"],
                     "id": 3
                 }, 
                 {
-                    "cell": ["false", "2", "1902F60E", "CES12086", "FW_HA", "02", "ha", "zone1-groupb", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.4", "dummyNetworkID2", "dummySubnetID2", "192.168.2.4"],
+                    "cell": ["false", "2", "1902F60E", "CES12086", "FW_HA", "02", "ha", "%s", "jp4_zone1", "dummyNetworkID1", "dummySubnetID1", "192.168.1.4", "dummyNetworkID2", "dummySubnetID2", "192.168.2.4"],
                     "id": 4
                 }
             ]
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)
 
 var testMockSecurityV1NetworkBasedDeviceHAUpdateInterface = fmt.Sprintf(`
 request:
@@ -1267,7 +1299,7 @@ counter:
     min: 4
 `
 
-var testMockSecurityV1NetworkBasedDeviceHAListAfterUpdateInterface = `
+var testMockSecurityV1NetworkBasedDeviceHAListAfterUpdateInterface = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1281,14 +1313,17 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES777", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES777", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES888", "UTM", "08", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES888", "UTM", "08", "standalone", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_NOVA_AVAILABLE_ZONE_HA,
+)

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_test.go
@@ -41,10 +41,10 @@ func TestAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", "zone1-groupa"),
+						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", "zone1-groupb"),
+						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
 				),
 			},
 			resource.TestStep{
@@ -63,10 +63,10 @@ func TestAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", "zone1-groupa"),
+						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", "zone1-groupb"),
+						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
 				),
 			},
 		},
@@ -110,10 +110,10 @@ func TestAccSecurityV1NetworkBasedDeviceHA_updateInterface(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", "zone1-groupa"),
+						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", "zone1-groupb"),
+						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
 
 					resource.TestCheckResourceAttrPtr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
@@ -386,8 +386,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "FW_HA"
 	license_kind = "02"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
   
 	ha_link_1 {
 		network_id = "${ecl_network_network_v2.network_1.id}"
@@ -408,6 +408,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )
 
 var testAccSecurityV1NetworkBasedDeviceHAUpdate = fmt.Sprintf(`
@@ -420,8 +422,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "UTM_HA"
 	license_kind = "08"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
   
 	ha_link_1 {
 		network_id = "${ecl_network_network_v2.network_1.id}"
@@ -442,6 +444,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )
 
 var testAccSecurityV1NetworkBasedDeviceHAIntrfaceUpdate = fmt.Sprintf(`
@@ -456,8 +460,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "FW_HA"
 	license_kind = "02"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
   
 	ha_link_1 {
 		network_id = "${ecl_network_network_v2.network_1.id}"
@@ -541,6 +545,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )
 
 var testAccSecurityV1NetworkBasedDeviceHAIntrfaceDisconnect = fmt.Sprintf(`
@@ -555,8 +561,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	operating_mode = "FW_HA"
 	license_kind = "02"
 
-	host_1_az_group = "zone1-groupa"
-	host_2_az_group = "zone1-groupb"
+	host_1_az_group = "%s"
+	host_2_az_group = "%s"
   
 	ha_link_1 {
 		network_id = "${ecl_network_network_v2.network_1.id}"
@@ -606,4 +612,6 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE_HA,
 )

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_test.go
@@ -41,10 +41,10 @@ func TestAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
+						"host_1_az_group", OS_DEFAULT_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
+						"host_2_az_group", OS_COMPUTE_ZONE_HA),
 				),
 			},
 			resource.TestStep{
@@ -63,10 +63,10 @@ func TestAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
+						"host_1_az_group", OS_DEFAULT_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
+						"host_2_az_group", OS_COMPUTE_ZONE_HA),
 				),
 			},
 		},
@@ -110,10 +110,10 @@ func TestAccSecurityV1NetworkBasedDeviceHA_updateInterface(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_1_az_group", OS_NOVA_AVAILABLE_ZONE),
+						"host_1_az_group", OS_DEFAULT_ZONE),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
-						"host_2_az_group", OS_NOVA_AVAILABLE_ZONE_HA),
+						"host_2_az_group", OS_COMPUTE_ZONE_HA),
 
 					resource.TestCheckResourceAttrPtr(
 						"ecl_security_network_based_device_ha_v1.ha_1",
@@ -408,8 +408,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testAccSecurityV1NetworkBasedDeviceHAUpdate = fmt.Sprintf(`
@@ -444,8 +444,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceHANetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testAccSecurityV1NetworkBasedDeviceHAIntrfaceUpdate = fmt.Sprintf(`
@@ -545,8 +545,8 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )
 
 var testAccSecurityV1NetworkBasedDeviceHAIntrfaceDisconnect = fmt.Sprintf(`
@@ -612,6 +612,6 @@ resource "ecl_security_network_based_device_ha_v1" "ha_1" {
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceUserNetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE_HA,
+	OS_DEFAULT_ZONE,
+	OS_COMPUTE_ZONE_HA,
 )

--- a/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
@@ -75,7 +75,7 @@ func TestMockedAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", OS_NOVA_AVAILABLE_ZONE),
+						"az_group", OS_DEFAULT_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -94,7 +94,7 @@ func TestMockedAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", OS_NOVA_AVAILABLE_ZONE),
+						"az_group", OS_DEFAULT_ZONE),
 				),
 			},
 		},
@@ -191,7 +191,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceSingleUpdate = fmt.Sprintf(`
@@ -204,7 +204,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceSingleUpdateInterface = fmt.Sprintf(`
@@ -257,7 +257,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleListBeforeCreate = fmt.Sprintf(`
@@ -280,7 +280,7 @@ expectedStatus:
     - ""
 newStatus: PreCreate
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleListAfterCreate = fmt.Sprintf(`
@@ -309,8 +309,8 @@ expectedStatus:
     - Created
     - Updating
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleListDeviceInterfaces = `
@@ -359,8 +359,8 @@ expectedStatus:
     - Updated
     - Created
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleListDevicesAfterUpdate = fmt.Sprintf(`
@@ -394,8 +394,8 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleListDeviceInterfacesAfterCreate = `
@@ -466,7 +466,7 @@ response:
 expectedStatus:
     - Deleted
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleCreate = fmt.Sprintf(`
@@ -663,8 +663,8 @@ response:
 expectedStatus:
     - Updated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleListAfterInterfaceUpdate = fmt.Sprintf(`
@@ -692,8 +692,8 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedDeviceSingleUpdateInterface = fmt.Sprintf(`
@@ -1105,6 +1105,6 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )

--- a/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
@@ -75,7 +75,7 @@ func TestMockedAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", "zone1-groupb"),
+						"az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -94,7 +94,7 @@ func TestMockedAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", "zone1-groupb"),
+						"az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 		},
@@ -187,10 +187,11 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "ja"
 	operating_mode = "FW"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceSingleUpdate = fmt.Sprintf(`
@@ -199,10 +200,11 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "en"
 	operating_mode = "UTM"
 	license_kind = "08"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedDeviceSingleUpdateInterface = fmt.Sprintf(`
@@ -212,7 +214,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "ja"
 	operating_mode = "FW"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 
   port {
       enable = "true"
@@ -255,9 +257,10 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
-var testMockSecurityV1NetworkBasedDeviceSingleListBeforeCreate = `
+var testMockSecurityV1NetworkBasedDeviceSingleListBeforeCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -270,15 +273,17 @@ response:
             "records": 1,
             "rows": [{
             	"id": 1,
-            	"cell": ["false", "1", "CES11810", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+            	"cell": ["false", "1", "CES11810", "FW", "02", "standalone", "%s", "jp4_zone1"]
             }]
         }
 expectedStatus:
     - ""
 newStatus: PreCreate
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedDeviceSingleListAfterCreate = `
+var testMockSecurityV1NetworkBasedDeviceSingleListAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -292,18 +297,21 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - Created
     - Updating
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedDeviceSingleListDeviceInterfaces = `
 request:
@@ -319,7 +327,7 @@ expectedStatus:
     - Created
 `
 
-var testMockSecurityV1NetworkBasedDeviceSingleListDevicesAfterCreate = `
+var testMockSecurityV1NetworkBasedDeviceSingleListDevicesAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -331,7 +339,7 @@ response:
               "msa_device_id": "CES11810",
               "os_server_id": "392a90bf-2c1b-45fd-8221-096894fff39d",
               "os_server_name": "UTM-CES11878",
-              "os_availability_zone": "zone1-groupb",
+              "os_availability_zone": "%s",
               "os_admin_username": "jp4_sdp_mss_utm_admin",
               "msa_device_type": "FW",
               "os_server_status": "ACTIVE"
@@ -340,7 +348,7 @@ response:
               "msa_device_id": "CES11811",
               "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278e",
               "os_server_name": "WAF-CES11816",
-              "os_availability_zone": "zone1-groupb",
+              "os_availability_zone": "%s",
               "os_admin_username": "jp4_sdp_mss_utm_admin",
               "msa_device_type": "WAF",
               "os_server_status": "ACTIVE"
@@ -350,9 +358,12 @@ response:
 expectedStatus:
     - Updated
     - Created
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedDeviceSingleListDevicesAfterUpdate = `
+var testMockSecurityV1NetworkBasedDeviceSingleListDevicesAfterUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -364,7 +375,7 @@ response:
                 "msa_device_id": "CES11810",
                 "os_server_id": "392a90bf-2c1b-45fd-8221-096894fff39d",
                 "os_server_name": "UTM-CES11878",
-                "os_availability_zone": "zone1-groupb",
+                "os_availability_zone": "%s",
                 "os_admin_username": "jp4_sdp_mss_utm_admin",
                 "msa_device_type": "FW",
                 "os_server_status": "ACTIVE"
@@ -373,7 +384,7 @@ response:
                 "msa_device_id": "CES11811",
                 "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278e",
                 "os_server_name": "WAF-CES11816",
-                "os_availability_zone": "zone1-groupb",
+                "os_availability_zone": "%s",
                 "os_admin_username": "jp4_sdp_mss_utm_admin",
                 "msa_device_type": "WAF",
                 "os_server_status": "ACTIVE"
@@ -382,7 +393,10 @@ response:
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedDeviceSingleListDeviceInterfacesAfterCreate = `
 request:
@@ -433,7 +447,7 @@ expectedStatus:
     - InterfaceIsUpdated
 `
 
-var testMockSecurityV1NetworkBasedDeviceSingleListAfterDelete = `
+var testMockSecurityV1NetworkBasedDeviceSingleListAfterDelete = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -446,12 +460,14 @@ response:
             "records": 1,
             "rows": [{
                 "id": 1,
-                "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "%s", "jp4_zone1"]
             }]
         }
 expectedStatus:
     - Deleted
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedDeviceSingleCreate = fmt.Sprintf(`
 request:
@@ -622,7 +638,7 @@ counter:
     min: 4
 `
 
-var testMockSecurityV1NetworkBasedDeviceSingleListAfterUpdate = `
+var testMockSecurityV1NetworkBasedDeviceSingleListAfterUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -636,19 +652,22 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "UTM", "08", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "UTM", "08", "standalone", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - Updated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedDeviceSingleListAfterInterfaceUpdate = `
+var testMockSecurityV1NetworkBasedDeviceSingleListAfterInterfaceUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -662,17 +681,20 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedDeviceSingleUpdateInterface = fmt.Sprintf(`
 request:
@@ -1058,7 +1080,7 @@ counter:
     min: 4
 `
 
-var testMockSecurityV1NetworkBasedDeviceSingleListAfterUpdateInterface = `
+var testMockSecurityV1NetworkBasedDeviceSingleListAfterUpdateInterface = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1072,14 +1094,17 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "FW", "02", "standalone", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "UTM", "08", "standalone", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "UTM", "08", "standalone", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)

--- a/ecl/resource_ecl_security_network_based_device_single_v1_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_test.go
@@ -40,7 +40,7 @@ func TestAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", "zone1-groupb"),
+						"az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -59,7 +59,7 @@ func TestAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", "zone1-groupb"),
+						"az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 		},
@@ -245,10 +245,11 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "ja"
 	operating_mode = "FW"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedDeviceSingleUpdate = fmt.Sprintf(`
@@ -257,10 +258,11 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "en"
 	operating_mode = "UTM"
 	license_kind = "08"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 const testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet1 = `
@@ -305,7 +307,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "ja"
 	operating_mode = "FW"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 
   port {
       enable = "true"
@@ -350,6 +352,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedDeviceSingleUpdateInterface2 = fmt.Sprintf(`
@@ -361,7 +364,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	locale = "ja"
 	operating_mode = "FW"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 
   port {
     enable = "false"
@@ -394,4 +397,5 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )

--- a/ecl/resource_ecl_security_network_based_device_single_v1_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_test.go
@@ -40,7 +40,7 @@ func TestAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "02"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", OS_NOVA_AVAILABLE_ZONE),
+						"az_group", OS_DEFAULT_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -59,7 +59,7 @@ func TestAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 						"license_kind", "08"),
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_device_single_v1.device_1",
-						"az_group", OS_NOVA_AVAILABLE_ZONE),
+						"az_group", OS_DEFAULT_ZONE),
 				),
 			},
 		},
@@ -249,7 +249,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedDeviceSingleUpdate = fmt.Sprintf(`
@@ -262,7 +262,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 const testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet1 = `
@@ -352,7 +352,7 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedDeviceSingleUpdateInterface2 = fmt.Sprintf(`
@@ -397,5 +397,5 @@ resource "ecl_security_network_based_device_single_v1" "device_1" {
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedDeviceSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
@@ -11,14 +11,8 @@ import (
 	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
-const SoIDOfWAFCreate = "FGWAF_809F858574E94699952D0D7E7C58C81B"
 const SoIDOfWAFUpdate = "FGWAF_809F858574E94699952D0D7E7C58C81C"
 const SoIDOfWAFDelete = "FGWAF_F2349100C7D24EF3ACD6B9A9F91FD220"
-
-// const ProcessIDOfUpdateInterface = 85385
-
-// const expectedNewSingleDeviceHostName = "CES11811"
-// const expectedNewSingleDeviceUUID = "12768064-e7c9-44d1-b01d-e66f138a278e"
 
 func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 	if OS_REGION_NAME != "RegionOne" {
@@ -71,7 +65,7 @@ func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "02"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", "zone1-groupb"),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -86,7 +80,7 @@ func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "08"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", "zone1-groupb"),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 		},
@@ -178,10 +172,11 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	tenant_id = "%s"
 	locale = "ja"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedWAFSingleUpdate = fmt.Sprintf(`
@@ -189,10 +184,11 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	tenant_id = "%s"
 	locale = "en"
 	license_kind = "08"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedWAFSingleUpdateInterface = fmt.Sprintf(`
@@ -201,7 +197,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	tenant_id = "%s"
 	locale = "ja"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 
   port {
       enable = "true"
@@ -215,9 +211,10 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
-var testMockSecurityV1NetworkBasedWAFSingleListBeforeCreate = `
+var testMockSecurityV1NetworkBasedWAFSingleListBeforeCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -230,15 +227,17 @@ response:
             "records": 1,
             "rows": [{
             	"id": 1,
-            	"cell": ["false", "1", "CES11810", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+            	"cell": ["false", "1", "CES11810", "WAF", "02", "%s", "jp4_zone1"]
             }]
         }
 expectedStatus:
     - ""
 newStatus: PreCreate
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedWAFSingleListAfterCreate = `
+var testMockSecurityV1NetworkBasedWAFSingleListAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -252,20 +251,23 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "WAF", "02", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "WAF", "02", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - Created
     - Updating
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterCreate = `
+var testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -277,7 +279,7 @@ response:
               "msa_device_id": "CES11810",
               "os_server_id": "392a90bf-2c1b-45fd-8221-096894fff39d",
               "os_server_name": "WAF-CES11878",
-              "os_availability_zone": "zone1-groupb",
+              "os_availability_zone": "%s",
               "os_admin_username": "jp4_sdp_mss_utm_admin",
               "msa_device_type": "WAF",
               "os_server_status": "ACTIVE"
@@ -286,7 +288,7 @@ response:
               "msa_device_id": "CES11811",
               "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278e",
               "os_server_name": "WAF-CES11816",
-              "os_availability_zone": "zone1-groupb",
+              "os_availability_zone": "%s",
               "os_admin_username": "jp4_sdp_mss_utm_admin",
               "msa_device_type": "WAF",
               "os_server_status": "ACTIVE"
@@ -296,9 +298,12 @@ response:
 expectedStatus:
     - Updated
     - Created
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterUpdate = `
+var testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -310,7 +315,7 @@ response:
               "msa_device_id": "CES11810",
               "os_server_id": "392a90bf-2c1b-45fd-8221-096894fff39d",
               "os_server_name": "WAF-CES11878",
-              "os_availability_zone": "zone1-groupb",
+              "os_availability_zone": "%s",
               "os_admin_username": "jp4_sdp_mss_utm_admin",
               "msa_device_type": "WAF",
               "os_server_status": "ACTIVE"
@@ -319,7 +324,7 @@ response:
               "msa_device_id": "CES11811",
               "os_server_id": "12768064-e7c9-44d1-b01d-e66f138a278e",
               "os_server_name": "WAF-CES11816",
-              "os_availability_zone": "zone1-groupb",
+              "os_availability_zone": "%s",
               "os_admin_username": "jp4_sdp_mss_utm_admin",
               "msa_device_type": "WAF",
               "os_server_status": "ACTIVE"
@@ -328,7 +333,10 @@ response:
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedWAFSingleListDeviceInterfacesAfterCreate = `
 request:
@@ -369,7 +377,7 @@ expectedStatus:
     - InterfaceIsUpdated
 `
 
-var testMockSecurityV1NetworkBasedWAFSingleListAfterDelete = `
+var testMockSecurityV1NetworkBasedWAFSingleListAfterDelete = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -382,12 +390,14 @@ response:
             "records": 1,
             "rows": [{
             	"id": 1,
-            	"cell": ["false", "1", "CES11810", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+            	"cell": ["false", "1", "CES11810", "WAF", "02", "%s", "jp4_zone1"]
             }]
         }
 expectedStatus:
     - Deleted
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedWAFSingleCreate = fmt.Sprintf(`
 request:
@@ -558,7 +568,7 @@ counter:
     min: 4
 `
 
-var testMockSecurityV1NetworkBasedWAFSingleListAfterUpdate = `
+var testMockSecurityV1NetworkBasedWAFSingleListAfterUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -572,19 +582,22 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "WAF", "02", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "WAF", "08", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "WAF", "08", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - Updated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
-var testMockSecurityV1NetworkBasedWAFSingleListAfterInterfaceUpdate = `
+var testMockSecurityV1NetworkBasedWAFSingleListAfterInterfaceUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -598,17 +611,20 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "WAF", "02", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "WAF", "02", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)
 
 var testMockSecurityV1NetworkBasedWAFSingleUpdateInterface = fmt.Sprintf(`
 request:
@@ -994,7 +1010,7 @@ counter:
     min: 4
 `
 
-var testMockSecurityV1NetworkBasedWAFSingleListAfterUpdateInterface = `
+var testMockSecurityV1NetworkBasedWAFSingleListAfterUpdateInterface = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1008,14 +1024,17 @@ response:
             "rows": [
                 {
                     "id": 1,
-                    "cell": ["false", "1", "CES11810", "WAF", "02", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11810", "WAF", "02", "%s", "jp4_zone1"]
                 },
                 {
                     "id": 2,
-                    "cell": ["false", "1", "CES11811", "WAF", "08", "zone1-groupb", "jp4_zone1"]
+                    "cell": ["false", "1", "CES11811", "WAF", "08", "%s", "jp4_zone1"]
                 }
             ]
         }
 expectedStatus:
     - InterfaceIsUpdated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_NOVA_AVAILABLE_ZONE,
+)

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
@@ -65,7 +65,7 @@ func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "02"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_DEFAULT_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -80,7 +80,7 @@ func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "08"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_DEFAULT_ZONE),
 				),
 			},
 		},
@@ -176,7 +176,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedWAFSingleUpdate = fmt.Sprintf(`
@@ -188,7 +188,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockedAccSecurityV1NetworkBasedWAFSingleUpdateInterface = fmt.Sprintf(`
@@ -211,7 +211,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleListBeforeCreate = fmt.Sprintf(`
@@ -234,7 +234,7 @@ expectedStatus:
     - ""
 newStatus: PreCreate
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleListAfterCreate = fmt.Sprintf(`
@@ -263,8 +263,8 @@ expectedStatus:
     - Created
     - Updating
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterCreate = fmt.Sprintf(`
@@ -299,8 +299,8 @@ expectedStatus:
     - Updated
     - Created
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterUpdate = fmt.Sprintf(`
@@ -334,8 +334,8 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleListDeviceInterfacesAfterCreate = `
@@ -396,7 +396,7 @@ response:
 expectedStatus:
     - Deleted
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleCreate = fmt.Sprintf(`
@@ -593,8 +593,8 @@ response:
 expectedStatus:
     - Updated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleListAfterInterfaceUpdate = fmt.Sprintf(`
@@ -622,8 +622,8 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testMockSecurityV1NetworkBasedWAFSingleUpdateInterface = fmt.Sprintf(`
@@ -1035,6 +1035,6 @@ response:
 expectedStatus:
     - InterfaceIsUpdated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
+	OS_DEFAULT_ZONE,
 )

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_test.go
@@ -36,7 +36,7 @@ func TestAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "02"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_DEFAULT_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -51,7 +51,7 @@ func TestAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "08"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_DEFAULT_ZONE),
 				),
 			},
 		},
@@ -188,7 +188,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedWAFSingleUpdate = fmt.Sprintf(`
@@ -200,7 +200,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 }
 `,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 const testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet1 = `
@@ -260,7 +260,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedWAFSingleUpdateInterface2 = fmt.Sprintf(`
@@ -281,5 +281,5 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_test.go
@@ -36,7 +36,7 @@ func TestAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "02"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", "zone1-groupb"),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 			resource.TestStep{
@@ -51,7 +51,7 @@ func TestAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_security_network_based_waf_single_v1.waf_1", "license_kind", "08"),
 					resource.TestCheckResourceAttr(
-						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", "zone1-groupb"),
+						"ecl_security_network_based_waf_single_v1.waf_1", "az_group", OS_NOVA_AVAILABLE_ZONE),
 				),
 			},
 		},
@@ -184,10 +184,11 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	tenant_id = "%s"
 	locale = "ja"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedWAFSingleUpdate = fmt.Sprintf(`
@@ -195,10 +196,11 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	tenant_id = "%s"
 	locale = "en"
 	license_kind = "08"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 }
 `,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 const testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet1 = `
@@ -242,7 +244,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	tenant_id = "%s"
 	locale = "ja"
 	license_kind = "02"
-	az_group = "zone1-groupb"
+	az_group = "%s"
 
     port {
         enable = "true"
@@ -258,6 +260,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testAccSecurityV1NetworkBasedWAFSingleUpdateInterface2 = fmt.Sprintf(`
@@ -268,7 +271,7 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
     tenant_id = "%s"
     locale = "ja"
     license_kind = "02"
-    az_group = "zone1-groupb"
+    az_group = "%s"
 
     port {
         enable = "false"
@@ -278,4 +281,5 @@ resource "ecl_security_network_based_waf_single_v1" "waf_1" {
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet1,
 	testAccSecurityV1NetworkBasedWAFSingleUpdateInterfaceNetworkSubnet2,
 	OS_TENANT_ID,
+	OS_NOVA_AVAILABLE_ZONE,
 )

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -279,7 +279,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
     interface_1_info  {
@@ -298,6 +298,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -306,7 +307,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
     interface_1_info  {
@@ -339,6 +340,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -347,7 +349,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1-update"
 	description = "appliance_1_description-update"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
     tags = {
@@ -375,6 +377,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -383,7 +386,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1-update"
 	description = "appliance_1_description-update"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
     interface_1_info  {
@@ -402,6 +405,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -410,7 +414,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
     interface_1_info  {
@@ -451,6 +455,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -467,7 +472,7 @@ expectedStatus:
 newStatus: Deleted
 `
 
-var testMockVNAV1ApplianceMetaPatch1 = `
+var testMockVNAV1ApplianceMetaPatch1 = fmt.Sprintf(`
 request:
     method: PATCH
 response:
@@ -476,7 +481,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description-update",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -572,16 +577,19 @@ response:
                 },
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
 expectedStatus:
     - Created
 newStatus: Updated1
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceMetaPatch2 = `
+var testMockVNAV1ApplianceMetaPatch2 = fmt.Sprintf(`
 request:
     method: PATCH
 response:
@@ -590,7 +598,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description-update",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -680,16 +688,19 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
 expectedStatus:
     - Updated1
 newStatus: Updated2
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceFixedIPPatch = `
+var testMockVNAV1ApplianceFixedIPPatch = fmt.Sprintf(`
 request:
     method: PATCH
 response:
@@ -702,9 +713,9 @@ response:
         		"description": "appliance_1_description",
         		"tags": {},
         		"appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-        		"availability_zone": "zone1-groupb",
+        		"availability_zone": "%s",
         		"tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-        		"virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+        		"virtual_network_appliance_plan_id": "%s",
         		"os_monitoring_status": "ACTIVE",
         		"os_login_status": "ACTIVE",
         		"vm_status": "ACTIVE",
@@ -797,9 +808,11 @@ response:
 expectedStatus:
     - Created
 newStatus: Updated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID)
 
-var testMockVNAV1ApplianceAllowedAddressPairPatch = `
+var testMockVNAV1ApplianceAllowedAddressPairPatch = fmt.Sprintf(`
 request:
     method: PATCH
 response:
@@ -812,9 +825,9 @@ response:
         		"description": "appliance_1_description",
         		"tags": {},
         		"appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-        		"availability_zone": "zone1-groupb",
+        		"availability_zone": "%s",
         		"tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-        		"virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+        		"virtual_network_appliance_plan_id": "%s",
         		"os_monitoring_status": "ACTIVE",
         		"os_login_status": "ACTIVE",
         		"vm_status": "ACTIVE",
@@ -913,9 +926,12 @@ response:
 expectedStatus:
 - Created
 newStatus: Updated
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1AppliancePost = `
+var testMockVNAV1AppliancePost = fmt.Sprintf(`
 request:
     method: POST
 response:
@@ -924,7 +940,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1015,14 +1031,17 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "initial"
             }
         }
 newStatus: Created
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceProcessingAfterCreate = `
+var testMockVNAV1ApplianceProcessingAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1031,7 +1050,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1122,7 +1141,7 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "initial"
             }
         }
@@ -1130,9 +1149,12 @@ expectedStatus:
     - Created
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceGetActiveAfterCreate = `
+var testMockVNAV1ApplianceGetActiveAfterCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1141,7 +1163,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1232,7 +1254,7 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -1240,7 +1262,10 @@ expectedStatus:
     - Created
 counter:
     min: 4
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
 var testMockVNAV1ApplianceGetDeleteComplete = `
 request:
@@ -1253,7 +1278,7 @@ counter:
     min: 4
 `
 
-var testMockVNAV1ApplianceProcessingAfterDelete = `
+var testMockVNAV1ApplianceProcessingAfterDelete = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1262,7 +1287,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1355,7 +1380,7 @@ response:
                 },
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -1363,9 +1388,12 @@ expectedStatus:
     - Deleted
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceProcessingAfterMetaUpdate1 = `
+var testMockVNAV1ApplianceProcessingAfterMetaUpdate1 = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1374,7 +1402,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description-update",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1470,7 +1498,7 @@ response:
                 },
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -1478,9 +1506,12 @@ expectedStatus:
     - Updated1
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceGetActiveAfterMetaUpdate1 = `
+var testMockVNAV1ApplianceGetActiveAfterMetaUpdate1 = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1489,7 +1520,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description-update",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1585,7 +1616,7 @@ response:
                 },
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -1593,8 +1624,12 @@ expectedStatus:
     - Updated1
 counter:
     min: 4
-`
-var testMockVNAV1ApplianceProcessingAfterMetaUpdate2 = `
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
+
+var testMockVNAV1ApplianceProcessingAfterMetaUpdate2 = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1603,7 +1638,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description-update",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1693,7 +1728,7 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -1701,9 +1736,12 @@ expectedStatus:
     - Updated2
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceGetActiveAfterMetaUpdate2 = `
+var testMockVNAV1ApplianceGetActiveAfterMetaUpdate2 = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1712,7 +1750,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description-update",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -1802,7 +1840,7 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -1810,9 +1848,12 @@ expectedStatus:
     - Updated2
 counter:
     min: 4
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceProcessingAfterFixedIPUpdate = `
+var testMockVNAV1ApplianceProcessingAfterFixedIPUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1825,9 +1866,9 @@ response:
         		"description": "appliance_1_description",
         		"tags": {},
         		"appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-        		"availability_zone": "zone1-groupb",
+        		"availability_zone": "%s",
         		"tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-        		"virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+        		"virtual_network_appliance_plan_id": "%s",
         		"os_monitoring_status": "ACTIVE",
         		"os_login_status": "ACTIVE",
         		"vm_status": "ACTIVE",
@@ -1921,9 +1962,12 @@ expectedStatus:
     - Updated
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceGetActiveAfterFixedIPUpdate = `
+var testMockVNAV1ApplianceGetActiveAfterFixedIPUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -1936,9 +1980,9 @@ response:
         		"description": "appliance_1_description",
         		"tags": {},
         		"appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-        		"availability_zone": "zone1-groupb",
+        		"availability_zone": "%s",
         		"tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-        		"virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+        		"virtual_network_appliance_plan_id": "%s",
         		"os_monitoring_status": "ACTIVE",
         		"os_login_status": "ACTIVE",
         		"vm_status": "ACTIVE",
@@ -2035,9 +2079,12 @@ expectedStatus:
     - Updated
 counter:
     min: 4
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceProcessingAfterAllowedAddressPairUpdate = `
+var testMockVNAV1ApplianceProcessingAfterAllowedAddressPairUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -2050,9 +2097,9 @@ response:
         		"description": "appliance_1_description",
         		"tags": {},
         		"appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-        		"availability_zone": "zone1-groupb",
+        		"availability_zone": "%s",
         		"tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-        		"virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+        		"virtual_network_appliance_plan_id": "%s",
         		"os_monitoring_status": "ACTIVE",
         		"os_login_status": "ACTIVE",
         		"vm_status": "ACTIVE",
@@ -2153,9 +2200,12 @@ expectedStatus:
     - Updated
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceGetActiveAfterAllowedAddressPairUpdate = `
+var testMockVNAV1ApplianceGetActiveAfterAllowedAddressPairUpdate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -2168,9 +2218,9 @@ response:
         		"description": "appliance_1_description",
         		"tags": {},
         		"appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-        		"availability_zone": "zone1-groupb",
+        		"availability_zone": "%s",
         		"tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-        		"virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+        		"virtual_network_appliance_plan_id": "%s",
         		"os_monitoring_status": "ACTIVE",
         		"os_login_status": "ACTIVE",
         		"vm_status": "ACTIVE",
@@ -2271,14 +2321,17 @@ expectedStatus:
     - Updated
 counter:
     min: 4
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
 var testMockedAccVNAV1ApplianceSimpleBasic = fmt.Sprintf(`
 resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	interface_1_info  {
@@ -2297,10 +2350,11 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
-var testMockVNAV1ApplianceSimplePost = `
+var testMockVNAV1ApplianceSimplePost = fmt.Sprintf(`
 request:
     method: POST
 response:
@@ -2309,7 +2363,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "default_gateway": "192.168.1.1",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
@@ -2400,14 +2454,17 @@ response:
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
                 "username": "root",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "initial"
             }
         }
 newStatus: Created
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceProcessingAfterSimpleCreate = `
+var testMockVNAV1ApplianceProcessingAfterSimpleCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -2416,7 +2473,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
                 "interfaces": {
@@ -2504,7 +2561,7 @@ response:
                 "os_monitoring_status": "initial",
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "initial"
             }
         }
@@ -2512,9 +2569,12 @@ expectedStatus:
     - Created
 counter:
     max: 3
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)
 
-var testMockVNAV1ApplianceGetActiveAfterSimpleCreate = `
+var testMockVNAV1ApplianceGetActiveAfterSimpleCreate = fmt.Sprintf(`
 request:
     method: GET
 response:
@@ -2523,7 +2583,7 @@ response:
         {
             "virtual_network_appliance": {
                 "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
-                "availability_zone": "zone1-groupb",
+                "availability_zone": "%s",
                 "description": "appliance_1_description",
                 "id": "45db3e66-31af-45a6-8ad2-d01521726145",
                 "interfaces": {
@@ -2611,7 +2671,7 @@ response:
                 "os_monitoring_status": "ACTIVE",
                 "tags": {},
                 "tenant_id": "9ee80f2a926c49f88f166af47df4e9f5",
-                "virtual_network_appliance_plan_id": "6589b37a-cf82-4918-96fe-255683f78e76",
+                "virtual_network_appliance_plan_id": "%s",
                 "vm_status": "ACTIVE"
             }
         }
@@ -2619,4 +2679,7 @@ expectedStatus:
     - Created
 counter:
     min: 4
-`
+`,
+	OS_NOVA_AVAILABLE_ZONE,
+	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
+)

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -298,7 +298,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -340,7 +340,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -377,7 +377,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -405,7 +405,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -455,7 +455,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -585,7 +585,7 @@ expectedStatus:
     - Created
 newStatus: Updated1
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -696,7 +696,7 @@ expectedStatus:
     - Updated1
 newStatus: Updated2
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -809,7 +809,7 @@ expectedStatus:
     - Created
 newStatus: Updated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID)
 
 var testMockVNAV1ApplianceAllowedAddressPairPatch = fmt.Sprintf(`
@@ -927,7 +927,7 @@ expectedStatus:
 - Created
 newStatus: Updated
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1037,7 +1037,7 @@ response:
         }
 newStatus: Created
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1150,7 +1150,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1263,7 +1263,7 @@ expectedStatus:
 counter:
     min: 4
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1389,7 +1389,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1507,7 +1507,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1625,7 +1625,7 @@ expectedStatus:
 counter:
     min: 4
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1737,7 +1737,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1849,7 +1849,7 @@ expectedStatus:
 counter:
     min: 4
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1963,7 +1963,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2080,7 +2080,7 @@ expectedStatus:
 counter:
     min: 4
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2201,7 +2201,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2322,7 +2322,7 @@ expectedStatus:
 counter:
     min: 4
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2350,7 +2350,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		]
 	}
 }`,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2460,7 +2460,7 @@ response:
         }
 newStatus: Created
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2570,7 +2570,7 @@ expectedStatus:
 counter:
     max: 3
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -2680,6 +2680,6 @@ expectedStatus:
 counter:
     min: 4
 `,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )

--- a/ecl/resource_ecl_vna_appliance_v1_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_test.go
@@ -617,7 +617,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -683,7 +683,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair3,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair4,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 var testAccVNAV1ApplianceRemoveFixedIP = fmt.Sprintf(`
@@ -748,7 +748,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair3,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair4,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -791,7 +791,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 	MaxLengthString,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccVNAV1ApplianceUpdateMetaBasic2 = fmt.Sprintf(`
@@ -823,7 +823,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -861,7 +861,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 	MaxLengthString,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 )
 
 var testAccVNAV1ApplianceUpdateAllowedAddressPairVRRP = fmt.Sprintf(`
@@ -903,7 +903,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -946,7 +946,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -984,7 +984,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1030,7 +1030,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1076,6 +1076,6 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
-	OS_NOVA_AVAILABLE_ZONE,
+	OS_DEFAULT_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )

--- a/ecl/resource_ecl_vna_appliance_v1_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_test.go
@@ -592,7 +592,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -617,6 +617,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -630,7 +631,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = [
@@ -682,6 +683,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair3,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair4,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 var testAccVNAV1ApplianceRemoveFixedIP = fmt.Sprintf(`
@@ -694,7 +696,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = [
@@ -746,6 +748,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair3,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair4,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -756,7 +759,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "%[3]s"
 	description = "%[3]s"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%[4]s"
 	virtual_network_appliance_plan_id = "%[2]s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -788,6 +791,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 	MaxLengthString,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testAccVNAV1ApplianceUpdateMetaBasic2 = fmt.Sprintf(`
@@ -797,7 +801,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = ""
 	description = ""
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -819,6 +823,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -829,7 +834,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "%[3]s"
 	description = "%[3]s"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%[4]s"
 	virtual_network_appliance_plan_id = "%[2]s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -856,6 +861,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 	MaxLengthString,
+	OS_NOVA_AVAILABLE_ZONE,
 )
 
 var testAccVNAV1ApplianceUpdateAllowedAddressPairVRRP = fmt.Sprintf(`
@@ -865,7 +871,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -897,6 +903,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -907,7 +914,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -939,6 +946,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -949,7 +957,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
@@ -976,6 +984,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	}
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -987,7 +996,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = [
@@ -1021,6 +1030,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )
 
@@ -1032,7 +1042,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	name = "appliance_1"
 	description = "appliance_1_description"
 	default_gateway = "192.168.1.1"
-	availability_zone = "zone1-groupb"
+	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = [
@@ -1066,5 +1076,6 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 }`,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair,
 	testAccVNAV1ApplianceSingleNetworkAndSubnetPair2,
+	OS_NOVA_AVAILABLE_ZONE,
 	OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID,
 )


### PR DESCRIPTION
Changed the availability zone directly in AccTest to environment variables.
Target Resource
- Compute Volume Attach
- Baremetal Server
- Baremetal Availability Zone
- Dedicated Hypervisor
- Tenant Connection
- Security Network Based device HA
- Security Network Based device Single
- Security Network Based WAF Single
- VNA