### PR TITLE
ExpectError message fixed typo

### DIFF
--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
@@ -162,7 +162,7 @@ func TestAccProviderConnectivityV2TenantConnection_multipleListAttachmentOpts(t 
 			},
 			resource.TestStep{
 				Config:      testAccProviderConnectivityV2TenantConnectionAttachmentOptsBaremetalMultipleList,
-				ExpectError: regexp.MustCompile("Too many attachment_opts_baremetal blocks: No more than 1 \"attachment_opts_barematal\" blocks are allowed"),
+				ExpectError: regexp.MustCompile("Too many attachment_opts_baremetal blocks: No more than 1 \"attachment_opts_baremetal\" blocks are allowed"),
 			},
 			resource.TestStep{
 				Config:      testAccProviderConnectivityV2TenantConnectionAttachmentOptsVnaMultipleList,


### PR DESCRIPTION
Fixed Typo of AccTest of TestAccProviderConnectivityV2TenantConnection_multipleListAttachmentOpts.

ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go L165
barematel → baremetal