### PR TITLE
Make mock tests run anywhere

### DIFF
--- a/ecl/data_source_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_mock_test.go
@@ -9,14 +9,10 @@ import (
 )
 
 func TestMockedAccNetworkV2InternetGatewayDataSource_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)
@@ -49,14 +45,10 @@ func TestMockedAccNetworkV2InternetGatewayDataSource_basic(t *testing.T) {
 }
 
 func TestMockedAccNetworkV2InternetGatewayDataSource_queries(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)

--- a/ecl/data_source_ecl_network_internet_gateway_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_test.go
@@ -33,6 +33,10 @@ func TestAccNetworkV2InternetGatewayDataSource_basic(t *testing.T) {
 }
 
 func TestAccNetworkV2InternetGatewayDataSource_queries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip this test in short mode")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckInternetGateway(t) },
 		Providers: testAccProviders,

--- a/ecl/data_source_ecl_network_internet_service_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_mock_test.go
@@ -9,14 +9,10 @@ import (
 )
 
 func TestMockedAccNetworkV2InternetServiceDataSource_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 
@@ -39,14 +35,10 @@ func TestMockedAccNetworkV2InternetServiceDataSource_basic(t *testing.T) {
 }
 
 func TestMockedAccNetworkV2InternetServiceDataSource_queries(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListIDQuery)

--- a/ecl/data_source_ecl_network_internet_service_v2_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccNetworkV2InternetServiceDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip this test in short mode")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckInternetService(t) },
 		Providers: testAccProviders,
@@ -26,6 +30,10 @@ func TestAccNetworkV2InternetServiceDataSource_basic(t *testing.T) {
 }
 
 func TestAccNetworkV2InternetServiceDataSource_queries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip this test in short mode")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckInternetService(t) },
 		Providers: testAccProviders,

--- a/ecl/fixtures.go
+++ b/ecl/fixtures.go
@@ -17,22 +17,22 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde0",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde1",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde2",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef"
                             }
                         ],
@@ -45,22 +45,22 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde4",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde5",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde6",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             }
                         ],
@@ -73,22 +73,22 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde8",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv3"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde9",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv3"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcdea",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv3"
                             }
                         ],
@@ -99,23 +99,23 @@ response:
                     {
                         "endpoints":[
                             {
-                                "region_id": "RegionOne",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region": "%[2]s",
                                 "interface": "public",
                                 "id": "1234567890abcdef1234567890abcdec"
                             },
                             {
-                                "region_id": "RegionOne",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region": "%[2]s",
                                 "interface": "admin",
                                 "id": "1234567890abcdef1234567890abcded"
                             },
                             {
-                                "region_id": "RegionOne",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region": "%[2]s",
                                 "interface": "internal",
                                 "id": "1234567890abcdef1234567890abcdee"
                             }
@@ -127,23 +127,23 @@ response:
                     {
                         "endpoints":[
                             {
-                                "region_id": "RegionOne",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv1/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region": "%[2]s",
                                 "interface": "public",
                                 "id": "1234567890abcdef1234567890abcdd0"
                             },
                             {
-                                "region_id": "RegionOne",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv1/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region": "%[2]s",
                                 "interface": "internal",
                                 "id": "1234567890abcdef1234567890abcdd1"
                             },
                             {
-                                "region_id": "RegionOne",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv1/01234567890123456789abcdefabcdef",
-                                "region": "RegionOne",
+                                "region": "%[2]s",
                                 "interface": "admin",
                                 "id": "1234567890abcdef1234567890abcdd2"
                             }
@@ -157,22 +157,22 @@ response:
                             {
                                 "id": "c4c383a719cb489d8210328e17659621",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "c4c383a719cb489d8210328e17659622",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "c4c383a719cb489d8210328e17659623",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             }
                         ],
@@ -185,22 +185,22 @@ response:
                             {
                                 "id": "d4c383a719cb489d8210328e17659621",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "d4c383a719cb489d8210328e17659622",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "d4c383a719cb489d8210328e17659623",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             }
                         ],
@@ -213,22 +213,22 @@ response:
                             {
                                 "id": "c4c383a719cb489d8210328e17659631",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "c4c383a719cb489d8210328e17659632",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             },
                             {
                                 "id": "c4c383a719cb489d8210328e17659633",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]s"
                             }
                         ],
@@ -241,22 +241,22 @@ response:
                             {
                                 "id": "1234567890abcdef1234567890abcde0",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde1",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef"
                             },
                             {
                                 "id": "1234567890abcdef1234567890abcde2",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv2/01234567890123456789abcdefabcdef"
                             }
                         ],
@@ -269,22 +269,22 @@ response:
                             {
                                 "id": "7c69821f-3246-4381-ba44-a91e4160cac6",
                                 "interface": "admin",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv1.0/1bc271e7a8af4d988ff91612f5b122f8"
                             },
                             {
                                 "id": "7c69821f-3246-4381-ba44-a91e4160cac6",
                                 "interface": "internal",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv1.0/1bc271e7a8af4d988ff91612f5b122f8"
                             },
                             {
                                 "id": "7c69821f-3246-4381-ba44-a91e4160cac6",
                                 "interface": "public",
-                                "region": "RegionOne",
-                                "region_id": "RegionOne",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
                                 "url": "%[1]sv1.0/1bc271e7a8af4d988ff91612f5b122f8"
                             }
                         ],

--- a/ecl/import_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/import_ecl_network_internet_gateway_v2_mock_test.go
@@ -9,16 +9,12 @@ import (
 )
 
 func TestMockedAccNetworkV2InternetGatewayImport_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	resourceName := "ecl_network_internet_gateway_v2.internet_gateway_1"
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)

--- a/ecl/resource_ecl_baremetal_server_v2_mock_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_mock_test.go
@@ -12,16 +12,12 @@ import (
 )
 
 func TestMockedBaremetalV2Server_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var server servers.Server
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "image", "/v2/01234567890123456789abcdefabcdef/images/detail", testMockImageV2ImageList)

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
@@ -12,16 +12,12 @@ import (
 )
 
 func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var server servers.Server
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "dedicated_hypervisor", "/v1.0/1bc271e7a8af4d988ff91612f5b122f8/servers", testMockDedicatedHypervisorV1ServerCreate)

--- a/ecl/resource_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/resource_ecl_network_internet_gateway_v2_mock_test.go
@@ -11,16 +11,12 @@ import (
 )
 
 func TestMockedAccNetworkV2InternetGateway_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var internetGateway internet_gateways.InternetGateway
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
 	mc.Register(t, "internet_service", "/v2.0/internet_services", testMockNetworkV2InternetServiceListNameQuery)
 	mc.Register(t, "internet_gateway", "/v2.0/internet_gateways", testMockNetworkV2InternetGatewayPost)

--- a/ecl/resource_ecl_security_host_based_v1_mock_test.go
+++ b/ecl/resource_ecl_security_host_based_v1_mock_test.go
@@ -17,16 +17,12 @@ const SoIDOfUpdateM2HostBased = "FGHA_809F858574E94699952D0D7E7C58C81C"
 const SoIDOfDeleteHostBased = "FGHA_F2349100C7D24EF3ACD6B9A9F91FD220"
 
 func TestMockedAccSecurityV1HostBased_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var hs security.HostBasedSecurity
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "host_based", "/API/SoEntryHBS", testMockSecurityV1HostBasedCreate)

--- a/ecl/resource_ecl_security_host_based_v1_mock_test.go
+++ b/ecl/resource_ecl_security_host_based_v1_mock_test.go
@@ -240,7 +240,7 @@ response:
             "service_order_service": "Managed Anti-Virus",
             "max_agent_value": 1,
             "time_zone": "Asia/Tokyo",
-            "mailaddress": "terraform@ntt.com",
+            "mailaddress": "hoge@example.com",
             "dsm_lang": "ja",
             "tenant_flg": true
         }
@@ -265,7 +265,7 @@ response:
             "service_order_service": "Managed Virtual Patch",
             "max_agent_value": 1,
             "time_zone": "Asia/Tokyo",
-            "mailaddress": "terraform@ntt.com",
+            "mailaddress": "hoge@example.com",
             "dsm_lang": "ja",
             "tenant_flg": true
         }
@@ -290,7 +290,7 @@ response:
             "service_order_service": "Managed Virtual Patch",
             "max_agent_value": 2,
             "time_zone": "Asia/Tokyo",
-            "mailaddress": "terraform@ntt.com",
+            "mailaddress": "hoge@example.com",
             "dsm_lang": "ja",
             "tenant_flg": true
         }

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
@@ -22,16 +22,12 @@ const expectedNewHADeviceUUID1 = "12768064-e7c9-44d1-b01d-e66f138a278e"
 const expectedNewHADeviceUUID2 = "12768064-e7c9-44d1-b01d-e66f138a278f"
 
 func TestMockedAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var hd1, hd2 security.HADevice
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	// TODO
@@ -111,16 +107,12 @@ func TestMockedAccSecurityV1NetworkBasedDeviceHA_basic(t *testing.T) {
 }
 
 func TestMockedAccSecurityV1NetworkBasedDeviceHAUpdateInterface(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var hd1, hd2 security.HADevice
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "ha_device", "/API/ScreenEventFGHADeviceGet", testMockSecurityV1NetworkBasedDeviceHAListBeforeCreate)

--- a/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
@@ -21,16 +21,12 @@ const expectedNewSingleDeviceHostName = "CES11811"
 const expectedNewSingleDeviceUUID = "12768064-e7c9-44d1-b01d-e66f138a278e"
 
 func TestMockedAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var sd security.SingleDevice
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "single_device", "/ecl-api/devices", testMockSecurityV1NetworkBasedDeviceSingleListDevicesAfterCreate)
@@ -102,16 +98,12 @@ func TestMockedAccSecurityV1NetworkBasedDeviceSingle_basic(t *testing.T) {
 }
 
 func TestMockedAccSecurityV1NetworkBasedDeviceSingleUpdateInterface(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var sd security.SingleDevice
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "single_device", "/API/ScreenEventFGSDeviceGet", testMockSecurityV1NetworkBasedDeviceSingleListBeforeCreate)

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
@@ -15,16 +15,12 @@ const SoIDOfWAFUpdate = "FGWAF_809F858574E94699952D0D7E7C58C81C"
 const SoIDOfWAFDelete = "FGWAF_F2349100C7D24EF3ACD6B9A9F91FD220"
 
 func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var sd security.SingleDevice
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "waf", "/ecl-api/devices", testMockSecurityV1NetworkBasedWAFSingleListDevicesAfterCreate)
@@ -88,16 +84,12 @@ func TestMockedAccSecurityV1NetworkBasedWAFSingle_basic(t *testing.T) {
 }
 
 func TestMockedAccSecurityV1NetworkBasedWAFSingleUpdateInterface(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var sd security.SingleDevice
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "waf", "/API/ScreenEventFGWAFDeviceGet", testMockSecurityV1NetworkBasedWAFSingleListBeforeCreate)

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -11,16 +11,12 @@ import (
 )
 
 func TestMockedAccVNAV1Appliance_updateMetaBasic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var vna appliances.Appliance
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "virtual_network_appliance", "/v1.0/virtual_network_appliances", testMockVNAV1AppliancePost)
@@ -87,16 +83,12 @@ func TestMockedAccVNAV1Appliance_updateMetaBasic(t *testing.T) {
 }
 
 func TestMockedAccVNAV1Appliance_updateAllowedAddressPairBasic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var vna appliances.Appliance
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "virtual_network_appliance", "/v1.0/virtual_network_appliances", testMockVNAV1AppliancePost)
@@ -138,16 +130,12 @@ func TestMockedAccVNAV1Appliance_updateAllowedAddressPairBasic(t *testing.T) {
 }
 
 func TestMockedAccVNAV1ApplianceUpdateFixedIP_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var vna appliances.Appliance
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "virtual_network_appliance", "/v1.0/virtual_network_appliances", testMockVNAV1AppliancePost)
@@ -195,16 +183,12 @@ func TestMockedAccVNAV1ApplianceUpdateFixedIP_basic(t *testing.T) {
 }
 
 func TestMockedAccVNAV1Appliance_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var vna appliances.Appliance
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "virtual_network_appliance", "/v1.0/virtual_network_appliances", testMockVNAV1AppliancePost)
@@ -238,16 +222,12 @@ func TestMockedAccVNAV1Appliance_basic(t *testing.T) {
 }
 
 func TestMockedAccVNAV1ApplianceSimple_basic(t *testing.T) {
-	if OS_REGION_NAME != "RegionOne" {
-		t.Skipf("skip this test in %s region", OS_REGION_NAME)
-	}
-
 	var vna appliances.Appliance
 
 	mc := mock.NewMockController()
 	defer mc.TerminateMockControllerSafety()
 
-	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint())
+	postKeystoneResponse := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystoneResponse)
 
 	mc.Register(t, "virtual_network_appliance", "/v1.0/virtual_network_appliances", testMockVNAV1ApplianceSimplePost)


### PR DESCRIPTION
* Make mock tests run in production regions by changing keystone response dynamically
* Remove skip logic of mock tests
* Fix mail address value in TestMockedAccSecurityV1HostBased_basic