### PR TITLE
Rename module to github.com/terraform-providers/terraform-provider-ecl

### DIFF
--- a/ecl/clientconfig/testing/fixtures.go
+++ b/ecl/clientconfig/testing/fixtures.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"github.com/nttcom/eclcloud"
-	"github.com/nttcom/terraform-provider-ecl/ecl/clientconfig"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/clientconfig"
 )
 
 var iTrue = true

--- a/ecl/clientconfig/testing/requests_test.go
+++ b/ecl/clientconfig/testing/requests_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/nttcom/eclcloud"
-	"github.com/nttcom/terraform-provider-ecl/ecl/clientconfig"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/clientconfig"
 
 	th "github.com/nttcom/eclcloud/testhelper"
 )

--- a/ecl/config.go
+++ b/ecl/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nttcom/eclcloud"
 	"github.com/nttcom/eclcloud/ecl"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/clientconfig"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/clientconfig"
 
 	"log"
 	"net/http"

--- a/ecl/data_source_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2InternetGatewayDataSource_basic(t *testing.T) {

--- a/ecl/data_source_ecl_network_internet_service_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2InternetServiceDataSource_basic(t *testing.T) {

--- a/ecl/import_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/import_ecl_network_internet_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2InternetGatewayImport_basic(t *testing.T) {

--- a/ecl/resource_ecl_baremetal_server_v2_mock_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_mock_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/nttcom/eclcloud/ecl/baremetal/v2/servers"
 )

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {

--- a/ecl/resource_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/resource_ecl_network_internet_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/nttcom/eclcloud/ecl/network/v2/internet_gateways"
 )

--- a/ecl/resource_ecl_security_host_based_v1_mock_test.go
+++ b/ecl/resource_ecl_security_host_based_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/host_based"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfCreateHostBased = "FGHA_809F858574E94699952D0D7E7C58C81B"

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/network_based_device_ha"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfCreateHA = "FGHA_809F858574E94699952D0D7E7C58C81B"

--- a/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/network_based_device_single"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfCreate = "FGS_809F858574E94699952D0D7E7C58C81B"

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/network_based_device_single"
 
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfWAFUpdate = "FGWAF_809F858574E94699952D0D7E7C58C81C"

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/nttcom/eclcloud/ecl/vna/v1/appliances"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nttcom/terraform-provider-ecl
+module github.com/terraform-providers/terraform-provider-ecl
 
 require (
 	github.com/hashicorp/terraform v0.12.6

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/nttcom/eclcloud v1.8.1 h1:oY8mwE/Nn9i2TGYSpBe1Dbdf0FjHCpxn2zDPGO1DnbI=
-github.com/nttcom/eclcloud v1.8.1/go.mod h1:PQHlN54VwpkUJ0Ep4p3Hd+S9wahseU7HxT5t2iAzr24=
 github.com/nttcom/eclcloud v1.9.0 h1:ers7lm/zAKo/vDoOG1XK5Cjz/c6yoZJfV2g8k5LI050=
 github.com/nttcom/eclcloud v1.9.0/go.mod h1:PQHlN54VwpkUJ0Ep4p3Hd+S9wahseU7HxT5t2iAzr24=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
@@ -344,8 +342,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200117160349-530e935923ad h1:Jh8cai0fqIK+f6nG0UgPW5wFk8wmiMhM3AyciDBdtQg=
-golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -363,8 +359,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab h1:9RfW3ktsOZxgo9YNbBAjq1FWzc/igwEcUzZz8IXgSbk=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCTu3mcIURZfNkVweuRKA=
-golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/nttcom/terraform-provider-ecl/ecl"
+	"github.com/terraform-providers/terraform-provider-ecl/ecl"
 )
 
 func main() {


### PR DESCRIPTION
This is a part of making official provider. Please look at the issue for more information.
https://github.com/nttcom/terraform-provider-ecl/issues/27