### PR TITLE
Add tenant connection mock test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,6 +43,9 @@ testacc-all: fmtcheck
 testacc-short: fmtcheck
 	TF_ACC=1 go test ./ecl -v -short -count=1 -timeout 5h -parallel 4
 
+testacc-args: fmtcheck
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -72,4 +75,4 @@ endif
 vendor:
 	go mod vendor
 
-.PHONY: build test testacc testacc-all testacc-short fmt fmtcheck errcheck lint tools test-compile website website-lint website-test vendor
+.PHONY: build test testacc testacc-all testacc-short testacc-args fmt fmtcheck errcheck lint tools test-compile website website-lint website-test vendor

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,7 @@ testacc-all: fmtcheck
 	TF_ACC=1 go test ./ecl -v -count=1 -timeout 24h -parallel 4
 
 testacc-short: fmtcheck
-	TF_ACC=1 go test ./ecl -v -short -count=1 -timeout 5h -parallel 4
+	TF_ACC=1 go test ./ecl -v -short -count=1 -timeout 180m -parallel 4
 
 testacc-args: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/ecl/fixtures.go
+++ b/ecl/fixtures.go
@@ -291,6 +291,34 @@ response:
                         "id": "7c69821f-3246-4381-ba44-a91e4160cac6",
                         "name": "dedicated-hypervisor",
                         "type": "dedicated-hypervisor"
+                    },
+                    {
+                        "endpoints": [
+                            {
+                                "id": "df7ca430-9fe3-11ea-b509-525403060400",
+                                "interface": "internal",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
+                                "url": "%[1]s"
+                            },
+                            {
+                                "id": "df7ca430-9fe3-11ea-b509-525403060400",
+                                "interface": "public",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
+                                "url": "%[1]s"
+                            },
+                            {
+                                "id": "df7ca430-9fe3-11ea-b509-525403060400",
+                                "interface": "admin",
+                                "region": "%[2]s",
+                                "region_id": "%[2]s",
+                                "url": "%[1]s"
+                            }
+                        ],
+                        "id": "df7ca430-9fe3-11ea-b509-525403060400",
+                        "name": "provider-connectivity",
+                        "type": "provider-connectivity"
                     }
                 ],
                 "expires_at": "2018-11-28T02:48:52.111201Z",

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
@@ -19,9 +19,8 @@ func TestMockedAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreate)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreate)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateServer)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreateServer)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionUpdate)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterUpdate)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionDelete)
@@ -101,7 +100,7 @@ resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 }
 `
 
-var testMockProviderConnectivityV2TenantConnectionCreate = `
+var testMockProviderConnectivityV2TenantConnectionCreateServer = `
 request:
     method: POST
 response:
@@ -132,7 +131,7 @@ response:
 newStatus: Created
 `
 
-var testMockProviderConnectivityV2TenantConnectionGetAfterCreate = `
+var testMockProviderConnectivityV2TenantConnectionGetAfterCreateServer = `
 request:
     method: GET
 response:
@@ -242,4 +241,131 @@ response:
     code: 404
 expectedStatus:
     - Deleted
+`
+
+func TestMockedAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T) {
+	var connection tenant_connections.TenantConnection
+
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateBaremetal)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterCreateBaremetal)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionDelete)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterDelete)
+
+	mc.StartServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckTenantConnection(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckProviderConnectivityV2TenantConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMockAccProviderConnectivityV2TenantConnectionBaremetalConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderConnectivityV2TenantConnectionExists("ecl_provider_connectivity_tenant_connection_v2.connection_1", &connection),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "id", "76ea7594-9ff9-11ea-9e55-525403060300"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_connection_request_id", "276a0de2-9ff7-11ea-9e55-525403060300"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "name", "test_name1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "description", "test_desc1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tags.test_tags1", "test1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_id", "2c76532f048849aab41c1bff2ec8b996"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_id_other", "7af0c902bd51424f8b2c85f5320ab181"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "network_id", "1b0d0417-9757-43b2-9885-a3625162be08"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_type", "ECL::Baremetal::Server"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_id", "b9cc6ca1-7b17-47b7-bb75-705a806204a4"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_interface_id", "1a76a0f6-ac2d-47e0-97ef-7222af0077b1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "port_id", "16253ba3-93eb-4629-a998-2e1d6ed978ed"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "status", "active"),
+				),
+			},
+		},
+	})
+}
+
+var testMockAccProviderConnectivityV2TenantConnectionBaremetalConfig = `
+resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
+	name = "test_name1"
+	description = "test_desc1"
+	tags = {
+		"test_tags1" = "test1"
+	}
+	tenant_connection_request_id = "276a0de2-9ff7-11ea-9e55-525403060300"
+	device_type = "ECL::Baremetal::Server"
+	device_id = "b9cc6ca1-7b17-47b7-bb75-705a806204a4"
+	device_interface_id = "1a76a0f6-ac2d-47e0-97ef-7222af0077b1"
+	attachment_opts_baremetal {
+		segmentation_type = "flat"
+		segmentation_id = 10
+		fixed_ips {
+			ip_address = "192.168.1.1"
+		}
+	}
+}
+`
+
+var testMockProviderConnectivityV2TenantConnectionCreateBaremetal = `
+request:
+    method: POST
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "b9cc6ca1-7b17-47b7-bb75-705a806204a4",
+                "device_interface_id": "1a76a0f6-ac2d-47e0-97ef-7222af0077b1",
+                "device_type": "ECL::Baremetal::Server",
+                "id": "76ea7594-9ff9-11ea-9e55-525403060300",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "1b0d0417-9757-43b2-9885-a3625162be08",
+                "port_id": "",
+                "status": "creating",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": "{}",
+                "tenant_connection_request_id": "276a0de2-9ff7-11ea-9e55-525403060300",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+newStatus: Created
+`
+
+var testMockProviderConnectivityV2TenantConnectionGetAfterCreateBaremetal = `
+request:
+    method: GET
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "b9cc6ca1-7b17-47b7-bb75-705a806204a4",
+                "device_interface_id": "1a76a0f6-ac2d-47e0-97ef-7222af0077b1",
+                "device_type": "ECL::Baremetal::Server",
+                "id": "76ea7594-9ff9-11ea-9e55-525403060300",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "1b0d0417-9757-43b2-9885-a3625162be08",
+                "port_id": "16253ba3-93eb-4629-a998-2e1d6ed978ed",
+                "status": "active",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": {},
+                "tenant_connection_request_id": "276a0de2-9ff7-11ea-9e55-525403060300",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+expectedStatus:
+    - Created
 `

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
@@ -1,0 +1,245 @@
+package ecl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections"
+
+	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMockedAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
+	var connection tenant_connections.TenantConnection
+
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionUpdate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterUpdate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionDelete)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterDelete)
+
+	mc.StartServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckTenantConnection(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckProviderConnectivityV2TenantConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMockAccProviderConnectivityV2TenantConnectionServerConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderConnectivityV2TenantConnectionExists("ecl_provider_connectivity_tenant_connection_v2.connection_1", &connection),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "id", "06969a7c-9fc0-11ea-b509-525403060400"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_connection_request_id", "fb1aae9a-9fbf-11ea-9e55-525403060300"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "name", "test_name1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "description", "test_desc1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tags.test_tags1", "test1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_id", "2c76532f048849aab41c1bff2ec8b996"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_id_other", "7af0c902bd51424f8b2c85f5320ab181"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "network_id", "69a7f763-adc7-4587-a43c-334942322f35"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_type", "ECL::Compute::Server"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_id", "46f97549-b3be-4a8a-a000-84f76d17f355"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_interface_id", ""),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "port_id", "bfc5e3f5-40cb-4f6a-a4a5-dc6e8a9e2f96"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "status", "active"),
+				),
+			},
+			{
+				Config: testMockAccProviderConnectivityV2TenantConnectionSeverUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "name", "updated_name"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "description", "updated_desc"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tags.k2", "v2"),
+				),
+			},
+		},
+	})
+}
+
+var testMockAccProviderConnectivityV2TenantConnectionServerConfig = `
+resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
+	name = "test_name1"
+	description = "test_desc1"
+	tags = {
+		"test_tags1" = "test1"
+	}
+	tenant_connection_request_id = "fb1aae9a-9fbf-11ea-9e55-525403060300"
+	device_type = "ECL::Compute::Server"
+	device_id = "46f97549-b3be-4a8a-a000-84f76d17f355"
+	attachment_opts_compute {
+		fixed_ips {
+			ip_address = "192.168.1.1"
+		}
+	}
+}
+`
+
+var testMockAccProviderConnectivityV2TenantConnectionSeverUpdateConfig = `
+resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
+	name = "updated_name"
+	description = "updated_desc"
+	tags = {
+		"k2" = "v2"
+	}
+	tenant_connection_request_id = "fb1aae9a-9fbf-11ea-9e55-525403060300"
+	device_type = "ECL::Compute::Server"
+	device_id = "46f97549-b3be-4a8a-a000-84f76d17f355"
+	attachment_opts_compute {
+		fixed_ips {
+			ip_address = "192.168.1.1"
+		}
+	}
+}
+`
+
+var testMockProviderConnectivityV2TenantConnectionCreate = `
+request:
+    method: POST
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "46f97549-b3be-4a8a-a000-84f76d17f355",
+                "device_interface_id": "",
+                "device_type": "ECL::Compute::Server",
+                "id": "06969a7c-9fc0-11ea-b509-525403060400",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "69a7f763-adc7-4587-a43c-334942322f35",
+                "port_id": "",
+                "status": "creating",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": {},
+                "tenant_connection_request_id": "fb1aae9a-9fbf-11ea-9e55-525403060300",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+newStatus: Created
+`
+
+var testMockProviderConnectivityV2TenantConnectionGetAfterCreate = `
+request:
+    method: GET
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "46f97549-b3be-4a8a-a000-84f76d17f355",
+                "device_interface_id": "",
+                "device_type": "ECL::Compute::Server",
+                "id": "06969a7c-9fc0-11ea-b509-525403060400",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "69a7f763-adc7-4587-a43c-334942322f35",
+                "port_id": "bfc5e3f5-40cb-4f6a-a4a5-dc6e8a9e2f96",
+                "status": "active",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": {},
+                "tenant_connection_request_id": "fb1aae9a-9fbf-11ea-9e55-525403060300",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+expectedStatus:
+    - Created
+`
+
+var testMockProviderConnectivityV2TenantConnectionUpdate = `
+request:
+    method: PUT
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "46f97549-b3be-4a8a-a000-84f76d17f355",
+                "device_interface_id": "",
+                "device_type": "ECL::Compute::Server",
+                "id": "06969a7c-9fc0-11ea-b509-525403060400",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "69a7f763-adc7-4587-a43c-334942322f35",
+                "port_id": "bfc5e3f5-40cb-4f6a-a4a5-dc6e8a9e2f96",
+                "status": "active",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": {},
+                "tenant_connection_request_id": "fb1aae9a-9fbf-11ea-9e55-525403060300",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+newStatus: Updated
+`
+
+var testMockProviderConnectivityV2TenantConnectionGetAfterUpdate = `
+request:
+    method: GET
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "updated_desc",
+                "description_other": "",
+                "device_id": "46f97549-b3be-4a8a-a000-84f76d17f355",
+                "device_interface_id": "",
+                "device_type": "ECL::Compute::Server",
+                "id": "06969a7c-9fc0-11ea-b509-525403060400",
+                "name": "updated_name",
+                "name_other": "",
+                "network_id": "69a7f763-adc7-4587-a43c-334942322f35",
+                "port_id": "bfc5e3f5-40cb-4f6a-a4a5-dc6e8a9e2f96",
+                "status": "active",
+                "tags": {
+                    "k2": "v2"
+                },
+                "tags_other": {},
+                "tenant_connection_request_id": "fb1aae9a-9fbf-11ea-9e55-525403060300",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+expectedStatus:
+    - Updated
+`
+
+var testMockProviderConnectivityV2TenantConnectionDelete = `
+request:
+    method: DELETE
+response:
+    code: 204
+newStatus: Deleted
+`
+
+var testMockProviderConnectivityV2TenantConnectionGetAfterDelete = `
+request:
+    method: GET
+response:
+    code: 404
+expectedStatus:
+    - Deleted
+`

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
@@ -369,3 +369,128 @@ response:
 expectedStatus:
     - Created
 `
+
+func TestMockedAccProviderConnectivityV2TenantConnection_vna(t *testing.T) {
+	var connection tenant_connections.TenantConnection
+
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateVna)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/a27e1006-a00a-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterCreateVna)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/a27e1006-a00a-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionDelete)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/a27e1006-a00a-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterDelete)
+
+	mc.StartServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckTenantConnection(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckProviderConnectivityV2TenantConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testMockAccProviderConnectivityV2TenantConnectionVnaConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderConnectivityV2TenantConnectionExists("ecl_provider_connectivity_tenant_connection_v2.connection_1", &connection),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "id", "a27e1006-a00a-11ea-9e55-525403060300"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_connection_request_id", "94e0f9cc-a00a-11ea-9ada-525403060500"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "name", "test_name1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "description", "test_desc1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tags.test_tags1", "test1"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_id", "2c76532f048849aab41c1bff2ec8b996"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "tenant_id_other", "7af0c902bd51424f8b2c85f5320ab181"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "network_id", "045d234e-203f-4e35-affb-a1d3ba0380e0"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_type", "ECL::VirtualNetworkAppliance::VSRX"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_id", "baab608e-7f3c-4b67-82b9-1e6fa7befc95"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "device_interface_id", "interface_2"),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "port_id", ""),
+					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "status", "active"),
+				),
+			},
+		},
+	})
+}
+
+var testMockAccProviderConnectivityV2TenantConnectionVnaConfig = `
+resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
+	name = "test_name1"
+	description = "test_desc1"
+	tags = {
+		"test_tags1" = "test1"
+	}
+	tenant_connection_request_id = "94e0f9cc-a00a-11ea-9ada-525403060500"
+	device_type = "ECL::VirtualNetworkAppliance::VSRX"
+	device_id = "baab608e-7f3c-4b67-82b9-1e6fa7befc95"
+ 	device_interface_id = "interface_2"
+	attachment_opts_vna {
+		fixed_ips {
+			ip_address = "192.168.1.1"
+		}
+	}
+}
+`
+
+var testMockProviderConnectivityV2TenantConnectionCreateVna = `
+request:
+    method: POST
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "baab608e-7f3c-4b67-82b9-1e6fa7befc95",
+                "device_interface_id": "interface_2",
+                "device_type": "ECL::VirtualNetworkAppliance::VSRX",
+                "id": "a27e1006-a00a-11ea-9e55-525403060300",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "045d234e-203f-4e35-affb-a1d3ba0380e0",
+                "port_id": "",
+                "status": "creating",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": "{}",
+                "tenant_connection_request_id": "94e0f9cc-a00a-11ea-9ada-525403060500",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+newStatus: Created
+`
+
+var testMockProviderConnectivityV2TenantConnectionGetAfterCreateVna = `
+request:
+    method: GET
+response:
+    code: 200
+    body: >
+        {
+            "tenant_connection": {
+                "description": "test_desc1",
+                "description_other": "",
+                "device_id": "baab608e-7f3c-4b67-82b9-1e6fa7befc95",
+                "device_interface_id": "interface_2",
+                "device_type": "ECL::VirtualNetworkAppliance::VSRX",
+                "id": "a27e1006-a00a-11ea-9e55-525403060300",
+                "name": "test_name1",
+                "name_other": "",
+                "network_id": "045d234e-203f-4e35-affb-a1d3ba0380e0",
+                "port_id": "",
+                "status": "active",
+                "tags": {
+                    "test_tags1": "test1"
+                },
+                "tags_other": {},
+                "tenant_connection_request_id": "94e0f9cc-a00a-11ea-9ada-525403060500",
+                "tenant_id": "2c76532f048849aab41c1bff2ec8b996",
+                "tenant_id_other": "7af0c902bd51424f8b2c85f5320ab181"
+            }
+        }
+expectedStatus:
+    - Created
+`

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
@@ -19,10 +19,10 @@ func TestMockedAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateServer)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreateServer)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionUpdate)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterUpdate)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateComputeServer)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterCreateComputeServer)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionUpdateComputeServer)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterUpdateComputeServer)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionDelete)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/06969a7c-9fc0-11ea-b509-525403060400", testMockProviderConnectivityV2TenantConnectionGetAfterDelete)
 
@@ -34,7 +34,7 @@ func TestMockedAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 		CheckDestroy: testAccCheckProviderConnectivityV2TenantConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testMockAccProviderConnectivityV2TenantConnectionServerConfig,
+				Config: testMockAccProviderConnectivityV2TenantConnectionComputeServerConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProviderConnectivityV2TenantConnectionExists("ecl_provider_connectivity_tenant_connection_v2.connection_1", &connection),
 					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "id", "06969a7c-9fc0-11ea-b509-525403060400"),
@@ -53,7 +53,7 @@ func TestMockedAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testMockAccProviderConnectivityV2TenantConnectionSeverUpdateConfig,
+				Config: testMockAccProviderConnectivityV2TenantConnectionComputeSeverUpdateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "name", "updated_name"),
 					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "description", "updated_desc"),
@@ -64,7 +64,7 @@ func TestMockedAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 	})
 }
 
-var testMockAccProviderConnectivityV2TenantConnectionServerConfig = `
+var testMockAccProviderConnectivityV2TenantConnectionComputeServerConfig = `
 resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 	name = "test_name1"
 	description = "test_desc1"
@@ -82,7 +82,7 @@ resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 }
 `
 
-var testMockAccProviderConnectivityV2TenantConnectionSeverUpdateConfig = `
+var testMockAccProviderConnectivityV2TenantConnectionComputeSeverUpdateConfig = `
 resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 	name = "updated_name"
 	description = "updated_desc"
@@ -100,7 +100,7 @@ resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 }
 `
 
-var testMockProviderConnectivityV2TenantConnectionCreateServer = `
+var testMockProviderConnectivityV2TenantConnectionCreateComputeServer = `
 request:
     method: POST
 response:
@@ -131,7 +131,7 @@ response:
 newStatus: Created
 `
 
-var testMockProviderConnectivityV2TenantConnectionGetAfterCreateServer = `
+var testMockProviderConnectivityV2TenantConnectionGetAfterCreateComputeServer = `
 request:
     method: GET
 response:
@@ -163,7 +163,7 @@ expectedStatus:
     - Created
 `
 
-var testMockProviderConnectivityV2TenantConnectionUpdate = `
+var testMockProviderConnectivityV2TenantConnectionUpdateComputeServer = `
 request:
     method: PUT
 response:
@@ -194,7 +194,7 @@ response:
 newStatus: Updated
 `
 
-var testMockProviderConnectivityV2TenantConnectionGetAfterUpdate = `
+var testMockProviderConnectivityV2TenantConnectionGetAfterUpdateComputeServer = `
 request:
     method: GET
 response:
@@ -251,8 +251,8 @@ func TestMockedAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T)
 
 	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
 	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateBaremetal)
-	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterCreateBaremetal)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections", testMockProviderConnectivityV2TenantConnectionCreateBaremetalServer)
+	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterCreateBaremetalServer)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionDelete)
 	mc.Register(t, "provider-connectivity", "/v2.0/tenant_connections/76ea7594-9ff9-11ea-9e55-525403060300", testMockProviderConnectivityV2TenantConnectionGetAfterDelete)
 
@@ -264,7 +264,7 @@ func TestMockedAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T)
 		CheckDestroy: testAccCheckProviderConnectivityV2TenantConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testMockAccProviderConnectivityV2TenantConnectionBaremetalConfig,
+				Config: testMockAccProviderConnectivityV2TenantConnectionBaremetalServerConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProviderConnectivityV2TenantConnectionExists("ecl_provider_connectivity_tenant_connection_v2.connection_1", &connection),
 					resource.TestCheckResourceAttr("ecl_provider_connectivity_tenant_connection_v2.connection_1", "id", "76ea7594-9ff9-11ea-9e55-525403060300"),
@@ -286,7 +286,7 @@ func TestMockedAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T)
 	})
 }
 
-var testMockAccProviderConnectivityV2TenantConnectionBaremetalConfig = `
+var testMockAccProviderConnectivityV2TenantConnectionBaremetalServerConfig = `
 resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 	name = "test_name1"
 	description = "test_desc1"
@@ -307,7 +307,7 @@ resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 }
 `
 
-var testMockProviderConnectivityV2TenantConnectionCreateBaremetal = `
+var testMockProviderConnectivityV2TenantConnectionCreateBaremetalServer = `
 request:
     method: POST
 response:
@@ -338,7 +338,7 @@ response:
 newStatus: Created
 `
 
-var testMockProviderConnectivityV2TenantConnectionGetAfterCreateBaremetal = `
+var testMockProviderConnectivityV2TenantConnectionGetAfterCreateBaremetalServer = `
 request:
     method: GET
 response:

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
@@ -50,6 +50,10 @@ func TestAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T) {
+	var connection tenant_connections.TenantConnection
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckTenantConnection(t) },
@@ -70,6 +74,10 @@ func TestAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccProviderConnectivityV2TenantConnection_vna(t *testing.T) {
+	var connection tenant_connections.TenantConnection
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckTenantConnection(t) },

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
@@ -510,6 +510,11 @@ resource "ecl_provider_connectivity_tenant_connection_v2" "connection_1" {
 	tenant_connection_request_id = "${ecl_provider_connectivity_tenant_connection_request_v2.request_1.id}"
 	device_type = "ECL::Compute::Server"
 	device_id = "${ecl_compute_instance_v2.instance_1.id}"
+	attachment_opts_compute {
+		fixed_ips {
+			ip_address = "192.168.1.1"
+		}
+	}
 }
 `,
 	oppositeTenantNetwork,

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip this test in short mode")
+	}
+
 	var connection tenant_connections.TenantConnection
 
 	resource.Test(t, resource.TestCase{
@@ -53,6 +57,10 @@ func TestAccProviderConnectivityV2TenantConnection_basic(t *testing.T) {
 }
 
 func TestAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip this test in short mode")
+	}
+
 	var connection tenant_connections.TenantConnection
 
 	resource.Test(t, resource.TestCase{
@@ -77,6 +85,10 @@ func TestAccProviderConnectivityV2TenantConnection_baremetal(t *testing.T) {
 }
 
 func TestAccProviderConnectivityV2TenantConnection_vna(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip this test in short mode")
+	}
+
 	var connection tenant_connections.TenantConnection
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
* Add testacc-args target
* Divide TestAccProviderConnectivityV2TenantConnection_basic into 3 test functions
* Fix test config in TestAccProviderConnectivityV2TenantConnection_basic
* Add skip option in tenant connection acc tests
* Add mock tests for tenant connection
* Change timeout of testacc(-short) target to 180m
