### PR TITLE
M miwa if 5192 fix vendor issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,5 @@ terraform-provider-ecl
 # editor specific settings
 .vscode
 
-# govendor
-vendor/*
-!vendor/vendor.json
-
 # own env files
 .myenvrc

--- a/ecl/clientconfig/testing/fixtures.go
+++ b/ecl/clientconfig/testing/fixtures.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"github.com/nttcom/eclcloud"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/clientconfig"
+	"github.com/nttcom/terraform-provider-ecl/ecl/clientconfig"
 )
 
 var iTrue = true

--- a/ecl/clientconfig/testing/requests_test.go
+++ b/ecl/clientconfig/testing/requests_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/nttcom/eclcloud"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/clientconfig"
+	"github.com/nttcom/terraform-provider-ecl/ecl/clientconfig"
 
 	th "github.com/nttcom/eclcloud/testhelper"
 )

--- a/ecl/config.go
+++ b/ecl/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nttcom/eclcloud"
 	"github.com/nttcom/eclcloud/ecl"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/clientconfig"
+	"github.com/nttcom/terraform-provider-ecl/ecl/clientconfig"
 
 	"log"
 	"net/http"

--- a/ecl/data_source_ecl_network_fic_gateway_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_fic_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2FICGatewayDataSource_name(t *testing.T) {

--- a/ecl/data_source_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_internet_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2InternetGatewayDataSource_basic(t *testing.T) {

--- a/ecl/data_source_ecl_network_internet_service_v2_mock_test.go
+++ b/ecl/data_source_ecl_network_internet_service_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2InternetServiceDataSource_basic(t *testing.T) {

--- a/ecl/import_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/import_ecl_network_internet_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedAccNetworkV2InternetGatewayImport_basic(t *testing.T) {

--- a/ecl/resource_ecl_baremetal_server_v2_mock_test.go
+++ b/ecl/resource_ecl_baremetal_server_v2_mock_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/nttcom/eclcloud/ecl/baremetal/v2/servers"
 )

--- a/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
+++ b/ecl/resource_ecl_dedicated_hypervisor_server_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 func TestMockedDedicatedHypervisorV1Server_basic(t *testing.T) {

--- a/ecl/resource_ecl_network_internet_gateway_v2_mock_test.go
+++ b/ecl/resource_ecl_network_internet_gateway_v2_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/nttcom/eclcloud/ecl/network/v2/internet_gateways"
 )

--- a/ecl/resource_ecl_network_load_balancer_v2_mock_test.go
+++ b/ecl/resource_ecl_network_load_balancer_v2_mock_test.go
@@ -2,8 +2,9 @@ package ecl
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
 	"testing"
+
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 // TestMockedAccNetworkV2LoadBalancer_basic tests basic behavior of Load Balancer creation and update requests.

--- a/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
+++ b/ecl/resource_ecl_provider_connectivity_tenant_connection_v2_mock_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/hashicorp/terraform/helper/resource"
 )

--- a/ecl/resource_ecl_security_host_based_v1_mock_test.go
+++ b/ecl/resource_ecl_security_host_based_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/host_based"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfCreateHostBased = "FGHA_809F858574E94699952D0D7E7C58C81B"

--- a/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_ha_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/network_based_device_ha"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfCreateHA = "FGHA_809F858574E94699952D0D7E7C58C81B"

--- a/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_device_single_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/network_based_device_single"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfCreate = "FGS_809F858574E94699952D0D7E7C58C81B"

--- a/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
+++ b/ecl/resource_ecl_security_network_based_waf_single_v1_mock_test.go
@@ -8,7 +8,7 @@ import (
 
 	security "github.com/nttcom/eclcloud/ecl/security_order/v1/network_based_device_single"
 
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 )
 
 const SoIDOfWAFUpdate = "FGWAF_809F858574E94699952D0D7E7C58C81C"

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl/testhelper/mock"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
 
 	"github.com/nttcom/eclcloud/ecl/vna/v1/appliances"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-ecl
+module github.com/nttcom/terraform-provider-ecl
 
 require (
 	github.com/hashicorp/terraform v0.12.6

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-ecl/ecl"
+	"github.com/nttcom/terraform-provider-ecl/ecl"
 )
 
 func main() {

--- a/vendor/github.com/nttcom/eclcloud/Makefile
+++ b/vendor/github.com/nttcom/eclcloud/Makefile
@@ -1,0 +1,13 @@
+fmt:
+	gofmt -s -w .
+
+fmtcheck:
+	(! gofmt -s -d . | grep '^')
+
+vet:
+	go vet ./...
+
+test:
+	go test ./... -count=1
+
+.PHONY: fmt fmtcheck vet test

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/doc.go
@@ -1,0 +1,35 @@
+/*
+Package fic_gateways provides information of several service
+in the Enterprise Cloud Compute service
+
+Example to List FIC Gateways
+
+	listOpts := fic_gateways.ListOpts{
+		Status: "ACTIVE",
+	}
+
+	allPages, err := fic_gateways.List(client, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allFICGateways, err := fic_gateways.ExtractFICGateways(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, ficGateway := range allFICGateways {
+		fmt.Printf("%+v", ficGateway)
+	}
+
+Example to Show FIC Gateway
+
+	id := "02dc9a22-129c-4b12-9936-4080f6a7ae44"
+	ficGateway, err := fic_gateways.Get(client, id).Extract()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(ficGateway)
+
+*/
+package fic_gateways

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/requests.go
@@ -1,0 +1,66 @@
+package fic_gateways
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToFICGatewaysListQuery() (string, error)
+}
+
+// ListOpts allows the filtering of paginated collections through the API.
+// Filtering is achieved by passing in struct field values that map to
+// the FIC Gateway attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListOpts struct {
+	// Description of the FIC Gateway resource.
+	Description string `q:"description"`
+
+	// 	FIC Service instantiated by this Gateway.
+	FICServiceID string `q:"fic_service_id"`
+
+	//Unique ID of the FIC Gateway resource.
+	ID string `q:"id"`
+
+	//Name of the FIC Gateway resource.
+	Name string `q:"name"`
+
+	// Quality of Service options selected for this Gateway.
+	QoSOptionID string `q:"qos_option_id"`
+
+	// The FIC Gateway status.
+	Status string `q:"status"`
+
+	// 	Tenant ID of the owner (UUID).
+	TenantID string `q:"tenant_id"`
+}
+
+// ToFICGatewaysListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToFICGatewaysListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list FIC Gateways accessible to you.
+func List(client *eclcloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToFICGatewaysListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return FICGatewayPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific FIC Gateway based on its unique ID.
+func Get(client *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/results.go
@@ -1,0 +1,53 @@
+package fic_gateways
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type FICGatewayPage struct {
+	pagination.LinkedPageBase
+}
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// GetResult is the result of Get operations. Call its Extract method to
+// interpret it as a FICGateway.
+type GetResult struct {
+	commonResult
+}
+
+// FICGateway represents a FIC Gateway.
+type FICGateway struct {
+	Description  string `json:"description"`
+	FICServiceID string `json:"fic_service_id"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	QoSOptionID  string `json:"qos_option_id"`
+	Status       string `json:"status"`
+	TenantID     string `json:"tenant_id"`
+}
+
+// IsEmpty checks whether a FICGatewayPage struct is empty.
+func (r FICGatewayPage) IsEmpty() (bool, error) {
+	is, err := ExtractFICGateways(r)
+	return len(is) == 0, err
+}
+
+// ExtractFICGateways accepts a Page struct, specifically a FICGatewayPage struct,
+// and extracts the elements into a slice of ListOpts structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractFICGateways(r pagination.Page) ([]FICGateway, error) {
+	var s []FICGateway
+	err := r.(FICGatewayPage).Result.ExtractIntoSlicePtr(&s, "fic_gateways")
+	return s, err
+}
+
+// Extract is a function that accepts a result and extracts a FICGateway.
+func (r GetResult) Extract() (*FICGateway, error) {
+	var l FICGateway
+	err := r.Result.ExtractIntoStructPtr(&l, "fic_gateway")
+	return &l, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/fic_gateways/urls.go
@@ -1,0 +1,11 @@
+package fic_gateways
+
+import "github.com/nttcom/eclcloud"
+
+func getURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("fic_gateways", id)
+}
+
+func listURL(client *eclcloud.ServiceClient) string {
+	return client.ServiceURL("fic_gateways")
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/doc.go
@@ -1,0 +1,51 @@
+/*
+Package load_balancer_interfaces contains functionality for working with
+ECL Load Balancer Interface resources.
+
+Example to List Load Balancer Interfaces
+
+	listOpts := load_balancer_interfaces.ListOpts{
+		Status: "ACTIVE",
+	}
+
+	allPages, err := load_balancer_interfaces.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadBalancerInterfaces, err := load_balancer_interfaces.ExtractLoadBalancerInterfaces(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, loadBalancerInterface := range allLoadBalancerInterfaces {
+		fmt.Printf("%+v\n", loadBalancerInterface)
+	}
+
+
+Example to Show Load Balancer Interface
+
+	loadBalancerInterfaceID := "f44e063c-5fea-45b8-9124-956995eafe2a"
+
+	loadBalancerInterface, err := load_balancer_interfaces.Get(networkClient, loadBalancerInterfaceID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", loadBalancerInterface)
+
+
+Example to Update Load Balancer Interface
+
+	loadBalancerInterfaceID := "f44e063c-5fea-45b8-9124-956995eafe2a"
+
+	updateOpts := load_balancer_interfaces.UpdateOpts{
+		Name:           "new_name",
+	}
+
+	loadBalancerInterface, err := load_balancer_interfaces.Update(networkClient, loadBalancerInterfaceID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package load_balancer_interfaces

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/requests.go
@@ -1,0 +1,138 @@
+package load_balancer_interfaces
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Load Balancer Interface attributes you want to see returned. SortKey allows you to sort
+// by a particular Load Balancer Interface attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Description      string `q:"description"`
+	ID               string `q:"id"`
+	IPAddress        string `q:"ip_address"`
+	LoadBalancerID   string `q:"load_balancer_id"`
+	Name             string `q:"name"`
+	NetworkID        string `q:"network_id"`
+	SlotNumber       int    `q:"slot_number"`
+	Status           string `q:"status"`
+	TenantID         string `q:"tenant_id"`
+	VirtualIPAddress string `q:"virtual_ip_address"`
+}
+
+// ToLoadBalancerInterfacesListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToLoadBalancerInterfacesListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Load Balancer Interfaces. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those Load Balancer Interfaces that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *eclcloud.ServiceClient, opts ListOpts) pagination.Pager {
+	url := listURL(c)
+	query, err := opts.ToLoadBalancerInterfacesListQuery()
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	url += query
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return LoadBalancerInterfacePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific Load Balancer Interface based on its unique ID.
+func Get(c *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOpts represents the attributes used when updating an existing Load Balancer Interface.
+type UpdateOpts struct {
+
+	// Description is description
+	Description *string `json:"description,omitempty"`
+
+	// IP Address
+	IPAddress string `json:"ip_address,omitempty"`
+
+	// Name of the Load Balancer Interface
+	Name *string `json:"name,omitempty"`
+
+	// UUID of the parent network.
+	NetworkID *interface{} `json:"network_id,omitempty"`
+
+	// Virtual IP Address
+	VirtualIPAddress *interface{} `json:"virtual_ip_address,omitempty"`
+
+	// Properties used for virtual IP address
+	VirtualIPProperties *VirtualIPProperties `json:"virtual_ip_properties,omitempty"`
+}
+
+// ToLoadBalancerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToLoadBalancerInterfaceUpdateMap() (map[string]interface{}, error) {
+	b, err := eclcloud.BuildRequestBody(opts, "load_balancer_interface")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Update accepts a UpdateOpts struct and updates an existing Load Balancer Interface using the
+// values provided.
+func Update(c *eclcloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToLoadBalancerInterfaceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, id), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convenience function that returns a Load Balancer Interface's ID,
+// given its name.
+func IDFromName(client *eclcloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractLoadBalancerInterfaces(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", eclcloud.ErrResourceNotFound{Name: name, ResourceType: "load_balancer_interface"}
+	case 1:
+		return id, nil
+	default:
+		return "", eclcloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "load_balancer_interface"}
+	}
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/results.go
@@ -1,0 +1,101 @@
+package load_balancer_interfaces
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Load Balancer Interface.
+type UpdateResult struct {
+	commonResult
+}
+
+// Extract is a function that accepts a result and extracts a Load Balancer Interface resource.
+func (r commonResult) Extract() (*LoadBalancerInterface, error) {
+	var s struct {
+		LoadBalancerInterface *LoadBalancerInterface `json:"load_balancer_interface"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoadBalancerInterface, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Load Balancer Interface.
+type GetResult struct {
+	commonResult
+}
+
+// Properties used for virtual IP address
+type VirtualIPProperties struct {
+	Protocol string `json:"protocol"`
+	Vrid     int    `json:"vrid"`
+}
+
+// LoadBalancerInterface represents a Load Balancer Interface. See package documentation for a top-level
+// description of what this is.
+type LoadBalancerInterface struct {
+
+	// Description is description
+	Description string `json:"description"`
+
+	// UUID representing the Load Balancer Interface.
+	ID string `json:"id"`
+
+	// IP Address
+	IPAddress *string `json:"ip_address"`
+
+	// The ID of load_balancer this load_balancer_interface belongs to.
+	LoadBalancerID string `json:"load_balancer_id"`
+
+	// Name of the Load Balancer Interface
+	Name string `json:"name"`
+
+	// UUID of the parent network.
+	NetworkID *string `json:"network_id"`
+
+	// Slot Number
+	SlotNumber int `json:"slot_number"`
+
+	// Load Balancer Interface status
+	Status string `json:"status"`
+
+	// Tenant ID of the owner (UUID)
+	TenantID string `json:"tenant_id"`
+
+	// Load Balancer Interface type
+	Type string `json:"type"`
+
+	// Virtual IP Address
+	VirtualIPAddress *string `json:"virtual_ip_address"`
+
+	// Properties used for virtual IP address
+	VirtualIPProperties *VirtualIPProperties `json:"virtual_ip_properties"`
+}
+
+// LoadBalancerPage is the page returned by a pager when traversing over a collection
+// of load balancers.
+type LoadBalancerInterfacePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a LoadBalancerInterfacePage struct is empty.
+func (r LoadBalancerInterfacePage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancerInterfaces(r)
+	return len(is) == 0, err
+}
+
+// ExtractLoadBalancerInterfaces accepts a Page struct, specifically a LoadBalancerPage struct,
+// and extracts the elements into a slice of Load Balancer Interface structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractLoadBalancerInterfaces(r pagination.Page) ([]LoadBalancerInterface, error) {
+	var s struct {
+		LoadBalancerInterfaces []LoadBalancerInterface `json:"load_balancer_interfaces"`
+	}
+	err := (r.(LoadBalancerInterfacePage)).ExtractInto(&s)
+	return s.LoadBalancerInterfaces, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces/urls.go
@@ -1,0 +1,23 @@
+package load_balancer_interfaces
+
+import "github.com/nttcom/eclcloud"
+
+func resourceURL(c *eclcloud.ServiceClient, id string) string {
+	return c.ServiceURL("load_balancer_interfaces", id)
+}
+
+func rootURL(c *eclcloud.ServiceClient) string {
+	return c.ServiceURL("load_balancer_interfaces")
+}
+
+func listURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func updateURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/doc.go
@@ -1,0 +1,37 @@
+/*
+Package load_balancer_plans contains functionality for working with
+ECL Load Balancer Plan resources.
+
+Example to List Load Balancer Plans
+
+	listOpts := load_balancer_plans.ListOpts{
+		Description: "general",
+	}
+
+	allPages, err := load_balancer_plans.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadBalancerPlans, err := load_balancer_plans.ExtractLoadBalancerPlans(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, loadBalancerPlan := range allLoadBalancerPlans {
+		fmt.Printf("%+v\n", loadBalancerPlan)
+	}
+
+Example to Show Load Balancer Plan
+
+	loadBalancerPlanID := "a46eeb5a-bc0a-40fa-b455-e5dc13b1220a"
+
+	loadBalancerPlan, err := load_balancer_plans.Get(networkClient, loadBalancerPlanID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", loadBalancerPlan)
+
+*/
+package load_balancer_plans

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/requests.go
@@ -1,0 +1,88 @@
+package load_balancer_plans
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Load Balancer Plan attributes you want to see returned. SortKey allows you to sort
+// by a particular Load Balancer Plan attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Description          string `q:"description"`
+	ID                   string `q:"id"`
+	MaximumSyslogServers int    `q:"maximum_syslog_servers"`
+	Name                 string `q:"name"`
+	Vendor               string `q:"vendor"`
+	Version              string `q:"version"`
+}
+
+// ToLoadBalancerPlansListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToLoadBalancerPlansListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Load Balancer Plans. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those Load Balancer Plans that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *eclcloud.ServiceClient, opts ListOpts) pagination.Pager {
+	url := listURL(c)
+	query, err := opts.ToLoadBalancerPlansListQuery()
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	url += query
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return LoadBalancerPlanPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific Load Balancer Plan based on its unique ID.
+func Get(c *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a Load Balancer Plan's ID,
+// given its name.
+func IDFromName(client *eclcloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractLoadBalancerPlans(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", eclcloud.ErrResourceNotFound{Name: name, ResourceType: "load_balancer_plan"}
+	case 1:
+		return id, nil
+	default:
+		return "", eclcloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "load_balancer_plan"}
+	}
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/results.go
@@ -1,0 +1,83 @@
+package load_balancer_plans
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Load Balancer Plan resource.
+func (r commonResult) Extract() (*LoadBalancerPlan, error) {
+	var s struct {
+		LoadBalancerPlan *LoadBalancerPlan `json:"load_balancer_plan"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoadBalancerPlan, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Load Balancer Plan.
+type GetResult struct {
+	commonResult
+}
+
+// Model of Load Balancer.
+type Model struct {
+	Edition string `json:"edition"`
+	Size    string `json:"size"`
+}
+
+// LoadBalancerPlan represents a Load Balancer Plan. See package documentation for a top-level
+// description of what this is.
+type LoadBalancerPlan struct {
+
+	// Description is description
+	Description string `json:"description"`
+
+	// Is user allowed to create new load balancers with this plan.
+	Enabled bool `json:"enabled"`
+
+	// UUID representing the Load Balancer Plan.
+	ID string `json:"id"`
+
+	// Maximum number of syslog servers
+	MaximumSyslogServers int `json:"maximum_syslog_servers"`
+
+	// Model of load balancer
+	Model Model `json:"model"`
+
+	// Name of the Load Balancer Plan
+	Name string `json:"name"`
+
+	// Load Balancer Type
+	Vendor string `json:"vendor"`
+
+	// Version name
+	Version string `json:"version"`
+}
+
+// LoadBalancerPlanPage is the page returned by a pager when traversing over a collection
+// of load balancer plans.
+type LoadBalancerPlanPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a LoadBalancerPlanPage struct is empty.
+func (r LoadBalancerPlanPage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancerPlans(r)
+	return len(is) == 0, err
+}
+
+// ExtractLoadBalancerPlans accepts a Page struct, specifically a LoadBalancerPage struct,
+// and extracts the elements into a slice of Load Balancer Plan structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractLoadBalancerPlans(r pagination.Page) ([]LoadBalancerPlan, error) {
+	var s struct {
+		LoadBalancerPlans []LoadBalancerPlan `json:"load_balancer_plans"`
+	}
+	err := (r.(LoadBalancerPlanPage)).ExtractInto(&s)
+	return s.LoadBalancerPlans, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_plans/urls.go
@@ -1,0 +1,19 @@
+package load_balancer_plans
+
+import "github.com/nttcom/eclcloud"
+
+func resourceURL(c *eclcloud.ServiceClient, id string) string {
+	return c.ServiceURL("load_balancer_plans", id)
+}
+
+func rootURL(c *eclcloud.ServiceClient) string {
+	return c.ServiceURL("load_balancer_plans")
+}
+
+func listURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/doc.go
@@ -1,0 +1,88 @@
+/*
+Package load_balancer_syslog_servers contains functionality for working with
+ECL Load Balancer Syslog Server resources.
+
+Example to List Load Balancer Syslog Servers
+
+	listOpts := load_balancer_syslog_servers.ListOpts{
+		Status: "ACTIVE",
+	}
+
+	allPages, err := load_balancer_syslog_servers.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadBalancerSyslogServers, err := load_balancer_syslog_servers.ExtractLoadBalancerSyslogServers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, loadBalancerSyslogServer := range allLoadBalancerSyslogServers {
+		fmt.Printf("%+v\n", loadBalancerSyslogServer)
+	}
+
+
+Example to Show Load Balancer Syslog Server
+
+	loadBalancerSyslogServerID := "9ab7ab3c-38a6-417c-926b-93772c4eb2f9"
+
+	loadBalancerSyslogServer, err := load_balancer_syslog_servers.Get(networkClient, loadBalancerSyslogServerID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", loadBalancerSyslogServer)
+
+
+Example to Create a Load Balancer Syslog Server
+
+	priority := 20
+
+	createOpts := load_balancer_syslog_servers.CreateOpts{
+		AclLogging:                  "DISABLED",
+		AppflowLogging:              "DISABLED",
+		DateFormat:                  "MMDDYYYY",
+		Description:                 "test",
+		IPAddress:                   "120.120.120.30",
+		LoadBalancerID:              "4f6ebc24-f768-485b-99ef-f308063d0209",
+		LogFacility:                 "LOCAL3",
+		LogLevel:                    "DEBUG",
+		Name:                        "first_syslog_server",
+		PortNumber:                  514,
+		Priority:                    &priority,
+		TcpLogging:                  "ALL",
+		TenantID:                    "b58531f716614e82a9bf001571c8bb15",
+		TimeZone:                    "LOCAL_TIME",
+		TransportType:               "UDP",
+		UserConfigurableLogMessages: "NO",
+	}
+
+	loadBalancerSyslogServer, err := load_balancer_syslog_servers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Load Balancer Syslog Server
+
+	loadBalancerSyslogServerID := "9ab7ab3c-38a6-417c-926b-93772c4eb2f9"
+	description := "new_description"
+
+	updateOpts := load_balancer_syslog_servers.UpdateOpts{
+		Description:           &description,
+	}
+
+	loadBalancerSyslogServer, err := load_balancer_syslog_servers.Update(networkClient, loadBalancerSyslogServerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Load Balancer Syslog Server
+
+	loadBalancerSyslogServerID := "13762eaf-9564-4c94-a106-98ece9fa189e"
+	err := load_balancer_syslog_servers.Delete(networkClient, loadBalancerSyslogServerID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package load_balancer_syslog_servers

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/requests.go
@@ -1,0 +1,233 @@
+package load_balancer_syslog_servers
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Load Balancer Syslog Server attributes you want to see returned. SortKey allows you to sort
+// by a particular Load Balancer Syslog Server attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Description    string `q:"description"`
+	ID             string `q:"id"`
+	IPAddress      string `q:"ip_address"`
+	LoadBalancerID string `q:"load_balancer_id"`
+	LogFacility    string `q:"log_facility"`
+	LogLevel       string `q:"log_level"`
+	Name           string `q:"name"`
+	PortNumber     int    `q:"port_number"`
+	Status         string `q:"status"`
+	TransportType  string `q:"transport_type"`
+}
+
+// ToLoadBalancerSyslogServersListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToLoadBalancerSyslogServersListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Load Balancer Syslog Servers. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those Load Balancer Syslog Servers that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *eclcloud.ServiceClient, opts ListOpts) pagination.Pager {
+	url := listURL(c)
+	query, err := opts.ToLoadBalancerSyslogServersListQuery()
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	url += query
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return LoadBalancerSyslogServerPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific Load Balancer Syslog Server based on its unique ID.
+func Get(c *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOpts represents the attributes used when creating a new Load Balancer Syslog Server.
+type CreateOpts struct {
+
+	// should syslog record acl info
+	AclLogging string `json:"acl_logging,omitempty"`
+
+	// should syslog record appflow info
+	AppflowLogging string `json:"appflow_logging,omitempty"`
+
+	// date format utilized by syslog
+	DateFormat string `json:"date_format,omitempty"`
+
+	// Description is description
+	Description string `json:"description,omitempty"`
+
+	// Ip address of syslog server
+	IPAddress string `json:"ip_address" required:"true"`
+
+	// The ID of load_balancer this load_balancer_syslog_server belongs to.
+	LoadBalancerID string `json:"load_balancer_id" required:"true"`
+
+	// 	Log facility for syslog
+	LogFacility string `json:"log_facility,omitempty"`
+
+	// Log level for syslog
+	LogLevel string `json:"log_level,omitempty"`
+
+	// Name is a human-readable name of the Load Balancer Syslog Server.
+	Name string `json:"name" required:"true"`
+
+	// Port number of syslog server
+	PortNumber int `json:"port_number,omitempty"`
+
+	// priority (0-255)
+	Priority *int `json:"priority,omitempty"`
+
+	// should syslog record tcp protocol info
+	TcpLogging string `json:"tcp_logging,omitempty"`
+
+	// The UUID of the project who owns the Load Balancer Syslog Server. Only administrative users
+	// can specify a project UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// time zone utilized by syslog
+	TimeZone string `json:"time_zone,omitempty"`
+
+	// protocol for syslog transport
+	TransportType string `json:"transport_type,omitempty"`
+
+	// can user configure log messages
+	UserConfigurableLogMessages string `json:"user_configurable_log_messages,omitempty"`
+}
+
+// ToLoadBalancerSyslogServerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToLoadBalancerSyslogServerCreateMap() (map[string]interface{}, error) {
+	b, err := eclcloud.BuildRequestBody(opts, "load_balancer_syslog_server")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Create accepts a CreateOpts struct and creates a new Load Balancer Syslog Server using the values
+// provided. You must remember to provide a valid LoadBalancerPlanID.
+func Create(c *eclcloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+	b, err := opts.ToLoadBalancerSyslogServerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// UpdateOpts represents the attributes used when updating an existing Load Balancer Syslog Server.
+type UpdateOpts struct {
+
+	// should syslog record acl info
+	AclLogging string `json:"acl_logging,omitempty"`
+
+	// should syslog record appflow info
+	AppflowLogging string `json:"appflow_logging,omitempty"`
+
+	// date format utilized by syslog
+	DateFormat string `json:"date_format,omitempty"`
+
+	// Description is description
+	Description *string `json:"description,omitempty"`
+
+	// 	Log facility for syslog
+	LogFacility string `json:"log_facility,omitempty"`
+
+	// Log level for syslog
+	LogLevel string `json:"log_level,omitempty"`
+
+	// priority (0-255)
+	Priority *int `json:"priority,omitempty"`
+
+	// should syslog record tcp protocol info
+	TcpLogging string `json:"tcp_logging,omitempty"`
+
+	// time zone utilized by syslog
+	TimeZone string `json:"time_zone,omitempty"`
+
+	// can user configure log messages
+	UserConfigurableLogMessages string `json:"user_configurable_log_messages,omitempty"`
+}
+
+// ToLoadBalancerSyslogServerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToLoadBalancerSyslogServerUpdateMap() (map[string]interface{}, error) {
+	b, err := eclcloud.BuildRequestBody(opts, "load_balancer_syslog_server")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Update accepts a UpdateOpts struct and updates an existing Load Balancer Syslog Server using the
+// values provided.
+func Update(c *eclcloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToLoadBalancerSyslogServerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, id), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the Load Balancer Syslog Server associated with it.
+func Delete(c *eclcloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a Load Balancer Syslog Server's ID,
+// given its name.
+func IDFromName(client *eclcloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractLoadBalancerSyslogServers(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", eclcloud.ErrResourceNotFound{Name: name, ResourceType: "load_balancer_syslog_server"}
+	case 1:
+		return id, nil
+	default:
+		return "", eclcloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "load_balancer_syslog_server"}
+	}
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/results.go
@@ -1,0 +1,125 @@
+package load_balancer_syslog_servers
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Load Balancer Syslog Server resource.
+func (r commonResult) Extract() (*LoadBalancerSyslogServer, error) {
+	var s struct {
+		LoadBalancerSyslogServer *LoadBalancerSyslogServer `json:"load_balancer_syslog_server"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoadBalancerSyslogServer, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Load Balancer Syslog Server.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Load Balancer Syslog Server.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Load Balancer Syslog Server.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	eclcloud.ErrResult
+}
+
+// LoadBalancerSyslogServer represents a Load Balancer Syslog Server. See package documentation for a top-level
+// description of what this is.
+type LoadBalancerSyslogServer struct {
+
+	// should syslog record acl info
+	AclLogging string `json:"acl_logging"`
+
+	// should syslog record appflow info
+	AppflowLogging string `json:"appflow_logging"`
+
+	// date format utilized by syslog
+	DateFormat string `json:"date_format"`
+
+	// Description is description
+	Description string `json:"description"`
+
+	// UUID representing the Load Balancer Syslog Server.
+	ID string `json:"id"`
+
+	// Ip address of syslog server
+	IPAddress string `json:"ip_address"`
+
+	// The ID of load_balancer this load_balancer_syslog_server belongs to.
+	LoadBalancerID string `json:"load_balancer_id"`
+
+	// 	Log facility for syslog
+	LogFacility string `json:"log_facility"`
+
+	// Log level for syslog
+	LogLevel string `json:"log_level"`
+
+	// Name of the syslog resource
+	Name string `json:"name"`
+
+	// Port number of syslog server
+	PortNumber int `json:"port_number"`
+
+	// priority (0-255)
+	Priority int `json:"priority"`
+
+	// Load balancer syslog server status
+	Status string `json:"status"`
+
+	// should syslog record tcp protocol info
+	TcpLogging string `json:"tcp_logging"`
+
+	// TenantID is the project owner of the Load Balancer Syslog Server.
+	TenantID string `json:"tenant_id"`
+
+	// time zone utilized by syslog
+	TimeZone string `json:"time_zone"`
+
+	// protocol for syslog transport
+	TransportType string `json:"transport_type"`
+
+	// can user configure log messages
+	UserConfigurableLogMessages string `json:"user_configurable_log_messages"`
+}
+
+// LoadBalancerSyslogServerPage is the page returned by a pager when traversing over a collection
+// of load balancer Syslog Servers.
+type LoadBalancerSyslogServerPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a LoadBalancerSyslogServerPage struct is empty.
+func (r LoadBalancerSyslogServerPage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancerSyslogServers(r)
+	return len(is) == 0, err
+}
+
+// ExtractLoadBalancerSyslogServers accepts a Page struct, specifically a LoadBalancerSyslogServerPage struct,
+// and extracts the elements into a slice of Load Balancer Syslog Server structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractLoadBalancerSyslogServers(r pagination.Page) ([]LoadBalancerSyslogServer, error) {
+	var s struct {
+		LoadBalancerSyslogServers []LoadBalancerSyslogServer `json:"load_balancer_syslog_servers"`
+	}
+	err := (r.(LoadBalancerSyslogServerPage)).ExtractInto(&s)
+	return s.LoadBalancerSyslogServers, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers/urls.go
@@ -1,0 +1,31 @@
+package load_balancer_syslog_servers
+
+import "github.com/nttcom/eclcloud"
+
+func resourceURL(c *eclcloud.ServiceClient, id string) string {
+	return c.ServiceURL("load_balancer_syslog_servers", id)
+}
+
+func rootURL(c *eclcloud.ServiceClient) string {
+	return c.ServiceURL("load_balancer_syslog_servers")
+}
+
+func listURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/doc.go
@@ -1,0 +1,75 @@
+/*
+Package load_balancers contains functionality for working with
+ECL Load Balancer resources.
+
+Example to List Load Balancers
+
+	listOpts := load_balancers.ListOpts{
+		Status: "ACTIVE",
+	}
+
+	allPages, err := load_balancers.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allLoadBalancers, err := load_balancers.ExtractLoadBalancers(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, loadBalancer := range allLoadBalancers {
+		fmt.Printf("%+v\n", loadBalancer)
+	}
+
+
+Example to Show Load Balancer
+
+	loadBalancerID := "f44e063c-5fea-45b8-9124-956995eafe2a"
+
+	loadBalancer, err := load_balancers.Get(networkClient, loadBalancerID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", loadBalancer)
+
+
+Example to Create a Load Balancer
+
+	createOpts := load_balancers.CreateOpts{
+		AvailabilityZone:   "zone1-groupa",
+		Description:        "Load Balancer 1",
+		LoadBalancerPlanID: "69bf1e91-73f6-41d5-84c4-91de21a9af05",
+		Name:               "abcdefghijklmnopqrstuvwxyz",
+		TenantID:           "5cc454d62d8c4a0595134b2632bf2263",
+	}
+
+	loadBalancer, err := load_balancers.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Load Balancer
+
+	loadBalancerID := "f44e063c-5fea-45b8-9124-956995eafe2a"
+	name := "new_name"
+
+	updateOpts := load_balancers.UpdateOpts{
+		Name:           &name,
+	}
+
+	loadBalancer, err := load_balancers.Update(networkClient, loadBalancerID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Load Balancer
+
+	loadBalancerID := "165fb257-2365-4c05-b368-a7bed21bb927"
+	err := load_balancers.Delete(networkClient, loadBalancerID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package load_balancers

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/requests.go
@@ -1,0 +1,182 @@
+package load_balancers
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Load Balancer attributes you want to see returned. SortKey allows you to sort
+// by a particular Load Balancer attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	AdminUsername      string `q:"admin_username"`
+	AvailabilityZone   string `q:"availability_zone"`
+	DefaultGateway     string `q:"default_gateway"`
+	Description        string `q:"description"`
+	ID                 string `q:"id"`
+	LoadBalancerPlanID string `q:"load_balancer_plan_id"`
+	Name               string `q:"name"`
+	Status             string `q:"status"`
+	TenantID           string `q:"tenant_id"`
+	UserUsername       string `q:"user_username"`
+}
+
+// ToLoadBalancersListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToLoadBalancersListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Load Balancers. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those Load Balancers that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *eclcloud.ServiceClient, opts ListOpts) pagination.Pager {
+	url := listURL(c)
+	query, err := opts.ToLoadBalancersListQuery()
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	url += query
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return LoadBalancerPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific Load Balancer based on its unique ID.
+func Get(c *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOpts represents the attributes used when creating a new Load Balancer.
+type CreateOpts struct {
+
+	// AvailabilityZone is one of the Virtual Server (Nova)’s availability zone.
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+
+	// Description is description
+	Description string `json:"description,omitempty"`
+
+	// LoadBalancerPlanID is the UUID of Load Balancer Plan.
+	LoadBalancerPlanID string `json:"load_balancer_plan_id" required:"true"`
+
+	// Name is a human-readable name of the Load Balancer.
+	Name string `json:"name,omitempty"`
+
+	// The UUID of the project who owns the Load Balancer. Only administrative users
+	// can specify a project UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
+// ToLoadBalancerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToLoadBalancerCreateMap() (map[string]interface{}, error) {
+	b, err := eclcloud.BuildRequestBody(opts, "load_balancer")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Create accepts a CreateOpts struct and creates a new Load Balancer using the values
+// provided. You must remember to provide a valid LoadBalancerPlanID.
+func Create(c *eclcloud.ServiceClient, opts CreateOpts) (r CreateResult) {
+	b, err := opts.ToLoadBalancerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// UpdateOpts represents the attributes used when updating an existing Load Balancer.
+type UpdateOpts struct {
+
+	// Description is description
+	DefaultGateway *interface{} `json:"default_gateway,omitempty"`
+
+	// Description is description
+	Description *string `json:"description,omitempty"`
+
+	// LoadBalancerPlanID is the UUID of Load Balancer Plan.
+	LoadBalancerPlanID string `json:"load_balancer_plan_id,omitempty"`
+
+	// Name is a human-readable name of the Load Balancer.
+	Name *string `json:"name,omitempty"`
+}
+
+// ToLoadBalancerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToLoadBalancerUpdateMap() (map[string]interface{}, error) {
+	b, err := eclcloud.BuildRequestBody(opts, "load_balancer")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Update accepts a UpdateOpts struct and updates an existing Load Balancer using the
+// values provided.
+func Update(c *eclcloud.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToLoadBalancerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, id), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the Load Balancer associated with it.
+func Delete(c *eclcloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a Load Balancer's ID,
+// given its name.
+func IDFromName(client *eclcloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractLoadBalancers(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", eclcloud.ErrResourceNotFound{Name: name, ResourceType: "load_balancer"}
+	case 1:
+		return id, nil
+	default:
+		return "", eclcloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "load_balancer"}
+	}
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/results.go
@@ -1,0 +1,115 @@
+package load_balancers
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_interfaces"
+	"github.com/nttcom/eclcloud/ecl/network/v2/load_balancer_syslog_servers"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Load Balancer resource.
+func (r commonResult) Extract() (*LoadBalancer, error) {
+	var s struct {
+		LoadBalancer *LoadBalancer `json:"load_balancer"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoadBalancer, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Load Balancer.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Load Balancer.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Load Balancer.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	eclcloud.ErrResult
+}
+
+// LoadBalancer represents a Load Balancer. See package documentation for a top-level
+// description of what this is.
+type LoadBalancer struct {
+
+	// AdminPassword is admin's password
+	AdminPassword string `json:"admin_password"`
+
+	// AdminUsername is admin's username
+	AdminUsername string `json:"admin_username"`
+
+	// AvailabilityZone is one of the Virtual Server (Nova)’s availability zone.
+	AvailabilityZone string `json:"availability_zone"`
+
+	// Description is description
+	DefaultGateway *string `json:"default_gateway"`
+
+	// Description is description
+	Description string `json:"description"`
+
+	// UUID representing the Load Balancer.
+	ID string `json:"id"`
+
+	// Attached interfaces by Load Balancer.
+	Interfaces []load_balancer_interfaces.LoadBalancerInterface `json:"interfaces"`
+
+	// LoadBalancerPlanID is the UUID of Load Balancer Plan.
+	LoadBalancerPlanID string `json:"load_balancer_plan_id"`
+
+	// Name of the Load Balancer.
+	Name string `json:"name"`
+
+	// The Load Balancer status.
+	Status string `json:"status"`
+
+	// Connected syslog servers.
+	SyslogServers []load_balancer_syslog_servers.LoadBalancerSyslogServer `json:"syslog_servers"`
+
+	// TenantID is the project owner of the Load Balancer.
+	TenantID string `json:"tenant_id"`
+
+	// User's password placeholder.
+	UserPassword string `json:"user_password"`
+
+	// User's username placeholder.
+	UserUsername string `json:"user_username"`
+}
+
+// LoadBalancerPage is the page returned by a pager when traversing over a collection
+// of load balancers.
+type LoadBalancerPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a LoadBalancerPage struct is empty.
+func (r LoadBalancerPage) IsEmpty() (bool, error) {
+	is, err := ExtractLoadBalancers(r)
+	return len(is) == 0, err
+}
+
+// ExtractLoadBalancers accepts a Page struct, specifically a LoadBalancerPage struct,
+// and extracts the elements into a slice of Load Balancer structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractLoadBalancers(r pagination.Page) ([]LoadBalancer, error) {
+	var s struct {
+		LoadBalancers []LoadBalancer `json:"load_balancers"`
+	}
+	err := (r.(LoadBalancerPage)).ExtractInto(&s)
+	return s.LoadBalancers, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/network/v2/load_balancers/urls.go
@@ -1,0 +1,31 @@
+package load_balancers
+
+import "github.com/nttcom/eclcloud"
+
+func resourceURL(c *eclcloud.ServiceClient, id string) string {
+	return c.ServiceURL("load_balancers", id)
+}
+
+func rootURL(c *eclcloud.ServiceClient) string {
+	return c.ServiceURL("load_balancers")
+}
+
+func listURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/doc.go
@@ -1,0 +1,79 @@
+/*
+Package tenant_connection_requests manages and retrieves Tenant Connection Request in the Enterprise Cloud Provider Connectivity Service.
+
+Example to List Tenant Connection Request
+
+	allPages, err := tenant_connection_requests.List(tcrClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allTenantConnectionRequests, err := tenant_connection_requests.ExtractTenantConnectionRequests(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, tenantConnectionRequest := range allTenantConnectionRequests {
+		fmt.Printf("%+v\n", tenantConnectionRequest)
+	}
+
+Example to Get a Tenant Connection Request
+
+	tenant_connection_request_id := "85a1dc30-2e48-11ea-9e55-525403060300"
+
+	tenantConnectionRequest, err := tenant_connection_requests.Get(tcrClient, tenant_connection_request_id).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", tenantConnectionRequest)
+
+Example to Create a Tenant Connection Request
+
+	createOpts := tenant_connection_requests.CreateOpts{
+		TenantIDOther: "7e91b19b9baa423793ee74a8e1ff2be1",
+		NetworkID: "c4d5fc41-b7e8-4f19-96f4-85299e54373c",
+		Name: "create_test_name",
+		Description: "create_test_desc",
+		Tags: map[string]string{"foo", "bar"},
+	}
+
+	result := tenant_connection_requests.Create(tcrClient, createOpts)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+Example to Update a Tenant Connection Request
+
+	tenant_connection_request_id := "85a1dc30-2e48-11ea-9e55-525403060300"
+	updateOpts := tenant_connection_requests.UpdateOpts{
+		Name: "update_test_name",
+		Description: "update_test_desc",
+		Tags: map[string]string{
+			"keyword1": "value1",
+			"keyword2": "value2",
+		},
+		NameOther: "update_test_name_other",
+		DescriptionOther: "update_test_desc_other",
+		TagsOther: map[string]string{
+			"keyword1": "value1",
+			"keyword2": "value2",
+		},
+	}
+
+	result := tenant_connection_requests.Update(tcrClient, tenant_connection_request_id, updateOpts)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+Example to Delete a Tenant Connection Request
+
+	tenant_connection_request_id := "85a1dc30-2e48-11ea-9e55-525403060300"
+
+	result := tenant_connection_requests.Delete(tcrClient, tenant_connection_request_id)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+*/
+package tenant_connection_requests

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/requests.go
@@ -1,0 +1,129 @@
+package tenant_connection_requests
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToTenantConnectionRequestListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	TenantConnectionRequestID string `q:"tenant_connection_request_id"`
+	Status                    string `q:"status"`
+	Name                      string `q:"name"`
+	TenantID                  string `q:"tenant_id"`
+	NameOther                 string `q:"name_other"`
+	TenantIDOther             string `q:"tenant_id_other"`
+	NetworkID                 string `q:"network_id"`
+	ApprovalRequestID         string `q:"approval_request_id"`
+}
+
+// ToTenantConnectionRequestListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTenantConnectionRequestListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List retrieves a list of Tenant Connection Requests.
+func List(client *eclcloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToTenantConnectionRequestListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return TenantConnectionRequestPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details of an Tenant Connection Request.
+func Get(client *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToTenantConnectionRequestCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts provides options used to create a Tenant Connection Request.
+type CreateOpts struct {
+	TenantIDOther string            `json:"tenant_id_other" required:"true"`
+	NetworkID     string            `json:"network_id" required:"true"`
+	Name          string            `json:"name,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	Tags          map[string]string `json:"tags,omitempty"`
+}
+
+// ToTenantConnectionRequestCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToTenantConnectionRequestCreateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "tenant_connection_request")
+}
+
+// Create creates a new Tenant Connection Request.
+func Create(client *eclcloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTenantConnectionRequestCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete deletes a Tenant Connection Request.
+func Delete(client *eclcloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), &eclcloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToTenantConnectionRequestUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents parameters to update a Tenant Connection Request.
+type UpdateOpts struct {
+	Name             *string            `json:"name,omitempty"`
+	Description      *string            `json:"description,omitempty"`
+	Tags             *map[string]string `json:"tags,omitempty"`
+	NameOther        *string            `json:"name_other,omitempty"`
+	DescriptionOther *string            `json:"description_other,omitempty"`
+	TagsOther        *map[string]string `json:"tags_other,omitempty"`
+}
+
+// ToResourceUpdateCreateMap formats a UpdateOpts into an update request.
+func (opts UpdateOpts) ToTenantConnectionRequestUpdateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "tenant_connection_request")
+}
+
+// Update modifies the attributes of a Tenant Connection Request.
+func Update(client *eclcloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToTenantConnectionRequestUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/results.go
@@ -1,0 +1,80 @@
+package tenant_connection_requests
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// TenantConnectionRequest represents Tenant Connection Request.
+type TenantConnectionRequest struct {
+	ID                string            `json:"id"`
+	Status            string            `json:"status"`
+	Name              string            `json:"name"`
+	Description       string            `json:"description"`
+	Tags              map[string]string `json:"tags"`
+	TenantID          string            `json:"tenant_id"`
+	NameOther         string            `json:"name_other"`
+	DescriptionOther  string            `json:"description_other"`
+	TagsOther         map[string]string `json:"tags_other"`
+	TenantIDOther     string            `json:"tenant_id_other"`
+	NetworkID         string            `json:"network_id"`
+	ApprovalRequestID string            `json:"approval_request_id"`
+}
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Tenant Connection Request.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Tenant Connection Request.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	eclcloud.ErrResult
+}
+
+// UpdateResult is the result of an Update request. Call its Extract method to
+// interpret it as a Tenant Connection Request.
+type UpdateResult struct {
+	commonResult
+}
+
+// TenantConnectionRequestPage is a single page of Tenant Connection Request results.
+type TenantConnectionRequestPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Tenant Connection Request contains any results.
+func (r TenantConnectionRequestPage) IsEmpty() (bool, error) {
+	resources, err := ExtractTenantConnectionRequests(r)
+	return len(resources) == 0, err
+}
+
+// ExtractTenantConnectionRequests returns a slice of Tenant Connection Requests contained in a
+// single page of results.
+func ExtractTenantConnectionRequests(r pagination.Page) ([]TenantConnectionRequest, error) {
+	var s struct {
+		TenantConnectionRequest []TenantConnectionRequest `json:"tenant_connection_requests"`
+	}
+	err := (r.(TenantConnectionRequestPage)).ExtractInto(&s)
+	return s.TenantConnectionRequest, err
+}
+
+// Extract interprets any commonResult as a Tenant Connection Request.
+func (r commonResult) Extract() (*TenantConnectionRequest, error) {
+	var s struct {
+		TenantConnectionRequest *TenantConnectionRequest `json:"tenant_connection_request"`
+	}
+	err := r.ExtractInto(&s)
+	return s.TenantConnectionRequest, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connection_requests/urls.go
@@ -1,0 +1,23 @@
+package tenant_connection_requests
+
+import "github.com/nttcom/eclcloud"
+
+func listURL(client *eclcloud.ServiceClient) string {
+	return client.ServiceURL("tenant_connection_requests")
+}
+
+func getURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("tenant_connection_requests", id)
+}
+
+func createURL(client *eclcloud.ServiceClient) string {
+	return client.ServiceURL("tenant_connection_requests")
+}
+
+func deleteURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("tenant_connection_requests", id)
+}
+
+func updateURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("tenant_connection_requests", id)
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/doc.go
@@ -1,0 +1,87 @@
+/*
+Package tenant_connections manages and retrieves Tenant Connection in the Enterprise Cloud Provider Connectivity Service.
+
+Example to List Tenant Connection
+
+	allPages, err := tenant_connections.List(tcClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allTenantConnections, err := tenant_connections.ExtractTenantConnections(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, tenantConnection := range allTenantConnections {
+		fmt.Printf("%+v\n", tenantConnection)
+	}
+
+Example to Get a Tenant Connection
+
+	tenant_connection_id := "ea5d975c-bd31-11e7-bcac-0050569c850d"
+
+	tenantConnection, err := tenant_connections.Get(tcClient, tenant_connection_id).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", tenantConnection)
+
+Example to Create a Tenant Connection
+
+	createOpts := tenant_connections.CreateOpts{
+		Name:                      "create_test_name",
+		Description:               "create_test_desc",
+		Tags: map[string]string{
+			"test_tags": "test",
+		},
+		TenantConnectionRequestID: "21b344d8-be11-11e7-bf3c-0050569c850d",
+		DeviceType:                "ECL::VirtualNetworkAppliance::VSRX",
+		DeviceID:                  "c291f4c4-a680-4db0-8b88-7e579f0aaa37",
+		DeviceInterfaceID:		   "interface_2",
+		AttachmentOpts: tenant_connections.Vna{
+			FixedIPs: []tenant_connections.VnaFixedIPs{
+				IPAddress: "192.168.1.3",
+			},
+		},
+	}
+
+	result := tenant_connections.Create(tcClient, createOpts)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+Example to Update a Tenant Connection
+
+	tenant_connection_id := "ea5d975c-bd31-11e7-bcac-0050569c850d"
+
+	updateOpts := tenant_connections.UpdateOpts{
+		Name: "test_name",
+		Description: "test_desc",
+		Tags: map[string]string{
+			"test_tags": "test",
+		},
+		NameOther: "test_name_other",
+		DescriptionOther: "test_desc_other",
+		TagsOther: map[string]string{
+			"test_tags_other": "test_other",
+		},
+	}
+
+	result := tenant_connections.Update(tcClient, tenant_connection_id, updateOpts)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+Example to Delete a Tenant Connection
+
+	tenant_connection_id := "ea5d975c-bd31-11e7-bcac-0050569c850d"
+
+	result := tenant_connections.Delete(tcClient, tenant_connection_id)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+*/
+package tenant_connections

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/requests.go
@@ -1,0 +1,171 @@
+package tenant_connections
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to
+// the List request
+type ListOptsBuilder interface {
+	ToTenantConnectionListQuery() (string, error)
+}
+
+// ListOpts provides options to filter the List results.
+type ListOpts struct {
+	TenantConnectionRequestID string `q:"tenant_connection_request_id"`
+	Status                    string `q:"status"`
+	Name                      string `q:"name"`
+	TenantID                  string `q:"tenant_id"`
+	NameOther                 string `q:"name_other"`
+	TenantIDOther             string `q:"tenant_id_other"`
+	NetworkID                 string `q:"network_id"`
+	DeviceType                string `q:"device_type"`
+	DeviceID                  string `q:"device_id"`
+	DeviceInterfaceID         string `q:"device_interface_id"`
+	PortID                    string `q:"port_id"`
+}
+
+// ToTenantConnectionListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToTenantConnectionListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List retrieves a list of Tenant Connection.
+func List(client *eclcloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToTenantConnectionListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return TenantConnectionPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details of an Tenant Connection.
+func Get(client *eclcloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to
+// the Create request.
+type CreateOptsBuilder interface {
+	ToTenantConnectionCreateMap() (map[string]interface{}, error)
+}
+
+// ServerFixedIPs contains the IP Address and the SubnetID.
+type ServerFixedIPs struct {
+	SubnetID  string `json:"subnet_id,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+// AddressPair contains the IP Address and the MAC address.
+type AddressPair struct {
+	IPAddress  string `json:"ip_address,omitempty"`
+	MACAddress string `json:"mac_address,omitempty"`
+}
+
+// VnaFixedIPs represents ip address part of virtual network appliance.
+type VnaFixedIPs struct {
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+// Vna represents the parameter when device_type is VSRX.
+type Vna struct {
+	FixedIPs []VnaFixedIPs `json:"fixed_ips,omitempty"`
+}
+
+// ComputeServer represents the parameter when device_type is Compute Server.
+type ComputeServer struct {
+	AllowedAddressPairs []AddressPair    `json:"allowed_address_pairs,omitempty"`
+	FixedIPs            []ServerFixedIPs `json:"fixed_ips,omitempty"`
+}
+
+// BaremetalServer represents the parameter when device_type is Baremetal Server.
+type BaremetalServer struct {
+	AllowedAddressPairs []AddressPair    `json:"allowed_address_pairs,omitempty"`
+	FixedIPs            []ServerFixedIPs `json:"fixed_ips,omitempty"`
+	SegmentationID      int              `json:"segmentation_id,omitempty"`
+	SegmentationType    string           `json:"segmentation_type,omitempty"`
+}
+
+// CreateOpts provides options used to create a Tenant Connection.
+type CreateOpts struct {
+	Name                      string            `json:"name,omitempty"`
+	Description               string            `json:"description,omitempty"`
+	Tags                      map[string]string `json:"tags,omitempty"`
+	TenantConnectionRequestID string            `json:"tenant_connection_request_id" required:"true"`
+	DeviceType                string            `json:"device_type" required:"true"`
+	DeviceID                  string            `json:"device_id" required:"true"`
+	DeviceInterfaceID         string            `json:"device_interface_id,omitempty"`
+	AttachmentOpts            interface{}       `json:"attachment_opts,omitempty"`
+}
+
+// ToTenantConnectionCreateMap formats a CreateOpts into a create request.
+func (opts CreateOpts) ToTenantConnectionCreateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "tenant_connection")
+}
+
+// Create creates a new Tenant Connection.
+func Create(client *eclcloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToTenantConnectionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), &b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete deletes a Tenant Connection.
+func Delete(client *eclcloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), &eclcloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToTenantConnectionUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents parameters to update a Tenant Connection.
+type UpdateOpts struct {
+	Name             *string            `json:"name,omitempty"`
+	Description      *string            `json:"description,omitempty"`
+	Tags             *map[string]string `json:"tags,omitempty"`
+	NameOther        *string            `json:"name_other,omitempty"`
+	DescriptionOther *string            `json:"description_other,omitempty"`
+	TagsOther        *map[string]string `json:"tags_other,omitempty"`
+}
+
+// ToTenantConnectionUpdateMap formats a UpdateOpts into an update request.
+func (opts UpdateOpts) ToTenantConnectionUpdateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "tenant_connection")
+}
+
+// Update modifies the attributes of a Tenant Connection.
+func Update(client *eclcloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToTenantConnectionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &eclcloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/results.go
@@ -1,0 +1,87 @@
+package tenant_connections
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// TenantConnection represents Tenant Connection.
+// TagsOther is interface{} because the data type returned by Create API depends on the value of device_type.
+// When the device_type of Create Request is ECL::Compute::Server, the data type of tags_other is map[].
+// When the device_type of Create Request is ECL::Baremetal::Server or ECL::VirtualNetworkAppliance::VSRX, the data type of tags_other is string.
+type TenantConnection struct {
+	ID                        string            `json:"id"`
+	TenantConnectionRequestID string            `json:"tenant_connection_request_id"`
+	Name                      string            `json:"name"`
+	Description               string            `json:"description"`
+	Tags                      map[string]string `json:"tags"`
+	TenantID                  string            `json:"tenant_id"`
+	NameOther                 string            `json:"name_other"`
+	DescriptionOther          string            `json:"description_other"`
+	TagsOther                 interface{}       `json:"tags_other"`
+	TenantIDOther             string            `json:"tenant_id_other"`
+	NetworkID                 string            `json:"network_id"`
+	DeviceType                string            `json:"device_type"`
+	DeviceID                  string            `json:"device_id"`
+	DeviceInterfaceID         string            `json:"device_interface_id"`
+	PortID                    string            `json:"port_id"`
+	Status                    string            `json:"status"`
+}
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as a Tenant Connection.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a Tenant Connection.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr to
+// determine if the request succeeded or failed.
+type DeleteResult struct {
+	eclcloud.ErrResult
+}
+
+// UpdateResult is the result of an Update request. Call its Extract method to
+// interpret it as a Tenant Connection.
+type UpdateResult struct {
+	commonResult
+}
+
+// TenantConnectionPage is a single page of Tenant Connection results.
+type TenantConnectionPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of Tenant Connection contains any results.
+func (r TenantConnectionPage) IsEmpty() (bool, error) {
+	resources, err := ExtractTenantConnections(r)
+	return len(resources) == 0, err
+}
+
+// ExtractTenantConnections returns a slice of Tenant Connections contained in a
+// single page of results.
+func ExtractTenantConnections(r pagination.Page) ([]TenantConnection, error) {
+	var s struct {
+		TenantConnection []TenantConnection `json:"tenant_connections"`
+	}
+	err := (r.(TenantConnectionPage)).ExtractInto(&s)
+	return s.TenantConnection, err
+}
+
+// Extract interprets any commonResult as a Tenant Connection.
+func (r commonResult) Extract() (*TenantConnection, error) {
+	var s struct {
+		TenantConnection *TenantConnection `json:"tenant_connection"`
+	}
+	err := r.ExtractInto(&s)
+	return s.TenantConnection, err
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/provider_connectivity/v2/tenant_connections/urls.go
@@ -1,0 +1,23 @@
+package tenant_connections
+
+import "github.com/nttcom/eclcloud"
+
+func listURL(client *eclcloud.ServiceClient) string {
+	return client.ServiceURL("tenant_connections")
+}
+
+func getURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("tenant_connections", id)
+}
+
+func createURL(client *eclcloud.ServiceClient) string {
+	return client.ServiceURL("tenant_connections")
+}
+
+func deleteURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("tenant_connections", id)
+}
+
+func updateURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("tenant_connections", id)
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/doc.go
@@ -1,0 +1,44 @@
+/*
+Package approval_requests manages and retrieves approval requests in the Enterprise Cloud.
+
+Example to List approval requests
+
+	allPages, err := approval_requests.List(client).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allApprovalRequests, err := approval_requests.ExtractApprovalRequests(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, approvalRequest := range allApprovalRequests {
+		fmt.Printf("%+v\n", approvalRequest)
+	}
+
+Example to Get an approval requests
+
+	requestID := "02471b45-3de0-4fc8-8469-a7cc52c378df"
+
+	approvalRequest, err := approval_requests.Get(client, requestID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", approvalRequest)
+
+Example to Update an approval request
+
+	requestID := "02471b45-3de0-4fc8-8469-a7cc52c378df"
+	updateOpts := approval_requests.UpdateOpts{
+		Status: "approved",
+	}
+
+	result := approval_requests.Update(client, requestID, updateOpts)
+	if result.Err != nil {
+		panic(result.Err)
+	}
+
+*/
+package approval_requests

--- a/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/requests.go
@@ -1,0 +1,77 @@
+package approval_requests
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToApprovalRequestListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the approval request attributes you want to see returned.
+type ListOpts struct {
+	Status  string `q:"status"`
+	Service string `q:"service"`
+}
+
+// ToApprovalRequestListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToApprovalRequestListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List retrieves a list of approval requests.
+func List(client *eclcloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToApprovalRequestListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ApprovalRequestPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves details of an approval request.
+func Get(client *eclcloud.ServiceClient, name string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, name), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateOptsBuilder interface {
+	ToResourceUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents parameters to update an approval request.
+type UpdateOpts struct {
+	Status string `json:"status" required:"true"`
+}
+
+// ToResourceUpdateCreateMap formats a UpdateOpts to update approval request.
+func (opts UpdateOpts) ToResourceUpdateMap() (map[string]interface{}, error) {
+	return eclcloud.BuildRequestBody(opts, "")
+}
+
+// Update modifies the attributes of an approval request.
+func Update(client *eclcloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToResourceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, nil, &eclcloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/results.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/results.go
@@ -1,0 +1,95 @@
+package approval_requests
+
+import (
+	"github.com/nttcom/eclcloud"
+	"github.com/nttcom/eclcloud/pagination"
+)
+
+type Action struct {
+	Service string `json:"service"`
+	Region  string `json:"region"`
+	APIPath string `json:"api_path"`
+	Method  string `json:"method"`
+	// Basically JSON is passed to Action.Body,
+	// but depending on the value of the service, it may be a String, so it is set to interface{}.
+	// If service is "provider-connectivity", body's type is JSON.
+	// If service is "network", body's type is String.
+	Body interface{} `json:"body"`
+}
+
+type Description struct {
+	Lang string `json:"lang"`
+	Text string `json:"text"`
+}
+
+// ApprovalRequest represents an ECL SSS Approval Request.
+type ApprovalRequest struct {
+	RequestID         string        `json:"request_id"`
+	ExternalRequestID string        `json:"external_request_id"`
+	ApproverType      string        `json:"approver_type"`
+	ApproverID        string        `json:"approver_id"`
+	RequestUserID     string        `json:"request_user_id"`
+	Service           string        `json:"service"`
+	Actions           []Action      `json:"actions"`
+	Descriptions      []Description `json:"descriptions"`
+	RequestUser       interface{}   `json:"request_user"`
+	Approver          bool          `json:"approver"`
+	ApprovalDeadLine  interface{}   `json:"approval_deadline"`
+	ApprovalExpire    interface{}   `json:"approval_expire"`
+	RegisteredTime    interface{}   `json:"registered_time"`
+	UpdatedTime       interface{}   `json:"updated_time"`
+	Status            string        `json:"status"`
+}
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+func (r commonResult) Extract() (*ApprovalRequest, error) {
+	var ar ApprovalRequest
+	err := r.ExtractInto(&ar)
+	return &ar, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}
+
+// GetResult is the response from a Get operation. Call its Extract method
+// to interpret it as an approval request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult is the result of an Update request. Call its Extract method to
+// interpret it as an approval request.
+type UpdateResult struct {
+	commonResult
+}
+
+// ApprovalRequestPage is a single page of approval request results.
+type ApprovalRequestPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of approval requests contains any results.
+func (r ApprovalRequestPage) IsEmpty() (bool, error) {
+	resources, err := ExtractApprovalRequests(r)
+	return len(resources) == 0, err
+}
+
+// ExtractApprovalRequests returns a slice of approval requests
+// contained in a single page of results.
+func ExtractApprovalRequests(r pagination.Page) ([]ApprovalRequest, error) {
+	var s struct {
+		ApprovalRequests []ApprovalRequest `json:"approval_requests"`
+	}
+	err := (r.(ApprovalRequestPage)).ExtractInto(&s)
+	return s.ApprovalRequests, err
+}
+
+// ExtractApprovalRequestsInto interprets the results of a single page from a List() call,
+// producing a slice of Approval Request entities.
+func ExtractApprovalRequestsInto(r pagination.Page, v interface{}) error {
+	return r.(ApprovalRequestPage).Result.ExtractIntoSlicePtr(v, "")
+}

--- a/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/ecl/sss/v1/approval_requests/urls.go
@@ -1,0 +1,15 @@
+package approval_requests
+
+import "github.com/nttcom/eclcloud"
+
+func listURL(client *eclcloud.ServiceClient) string {
+	return client.ServiceURL("approval-requests")
+}
+
+func getURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("approval-requests", id)
+}
+
+func updateURL(client *eclcloud.ServiceClient, id string) string {
+	return client.ServiceURL("approval-requests", id)
+}


### PR DESCRIPTION
* Revert its own Go module path from `github/terraform-providers/terraform-provider/ecl` to `github/nttcom/terraform-provider/ecl`
* Remove `vendor` directory from .gitignore file
* Make vendor directory up to date