### PR TITLE
remove full-width space in documents

### DIFF
--- a/website/docs/d/sss_tenant_v1.html.markdown
+++ b/website/docs/d/sss_tenant_v1.html.markdown
@@ -28,6 +28,6 @@ The following attributes are exported:
 
 * `description` - Description for this tenant.
 * `tenant_region` - Region this tenant belongs to.
-* `contract_id` -　Contract which new tenant belongs to.
+* `contract_id` - Contract which new tenant belongs to.
 * `start_time` - Tenant created time.
 * `tenant_id` - ID of the tenant.

--- a/website/docs/r/storage_volume_v1.html.markdown
+++ b/website/docs/r/storage_volume_v1.html.markdown
@@ -21,7 +21,7 @@ resource "ecl_storage_volume_v1" "volume_1" {
   virtual_storage_id = "3253f1a0-9f01-4cc7-904b-8eeaec317c03"
   iops_per_gb = "2"
   size = 100
-  initiator_iqns =　[
+  initiator_iqns = [
     "iqn.2003-01.org.sample-iscsi.node1.x8664:sn.2613f8620d98"
   ]
 }


### PR DESCRIPTION
This Pull Request did the following.

- Replace full-width spaces in the sample code in the storage volume documentation with single-byte spaces
- Replace full-width spaces detected by `git grep '　'` with single-byte spaces