### PR TITLE
Support VNA plan

### DIFF
--- a/ecl/data_source_ecl_vna_appliance_plan_v1.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1.go
@@ -1,0 +1,223 @@
+package ecl
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/nttcom/eclcloud/v2"
+	"github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceVNAAppliancePlanV1() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVNAAppliancePlanV1Read,
+
+		Schema: map[string]*schema.Schema{
+
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"appliance_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"flavor": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"number_of_interfaces": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"max_number_of_aap": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
+			"licenses": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"license_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"available": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"rank": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVNAAppliancePlanV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	var opts appliance_plans.ListOpts
+
+	if v, ok := d.GetOk("id"); ok {
+		opts.ID = v.(string)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		opts.Name = v.(string)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		opts.Description = v.(string)
+	}
+	if v, ok := d.GetOk("appliance_type"); ok {
+		opts.ApplianceType = v.(string)
+	}
+	if v, ok := d.GetOk("version"); ok {
+		opts.Version = v.(string)
+	}
+	if v, ok := d.GetOk("flavor"); ok {
+		opts.Flavor = v.(string)
+	}
+	if v, ok := d.GetOk("number_of_interfaces"); ok {
+		opts.NumberOfInterfaces = v.(int)
+	}
+	if v, ok := d.GetOk("enabled"); ok {
+		opts.Enabled = v.(bool)
+	}
+	if v, ok := d.GetOk("max_number_of_aap"); ok {
+		opts.MaxNumberOfAap = v.(int)
+	}
+	if v, ok := d.GetOk("availability_zone"); ok {
+		opts.AvailabilityZone = v.(string)
+	}
+	if v, ok := d.GetOk("availability_zone.available"); ok {
+		opts.AvailabilityZoneAvailable = v.(bool)
+	}
+
+	vnaClient, err := config.vnaV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating ECL virtual network appliance client: %s", err)
+	}
+
+	allPlans, err := getVirtualNetworkAppliancePlans(vnaClient, opts)
+	if err != nil {
+		return fmt.Errorf("error getting Load Balancer Plans: %w", err)
+	}
+
+	if len(allPlans) > 1 {
+		return fmt.Errorf("specified Virtual Network Appliance Plan query returned more than one result")
+	}
+
+	if len(allPlans) == 0 {
+		return fmt.Errorf("specified Virtual Network Appliance Plan query returned no results")
+	}
+
+	plan := allPlans[0]
+
+	log.Printf("[DEBUG] Retrieved Virtual Network Appliance Plan %s: %+v", plan.ID, plan)
+
+	d.SetId(plan.ID)
+	d.Set("id", plan.ID)
+	d.Set("name", plan.Name)
+	d.Set("description", plan.Description)
+	d.Set("appliance_type", plan.ApplianceType)
+	d.Set("version", plan.Version)
+	d.Set("flavor", plan.Flavor)
+	d.Set("number_of_interfaces", plan.NumberOfInterfaces)
+	d.Set("enabled", plan.Enabled)
+	d.Set("max_number_of_aap", plan.MaxNumberOfAap)
+
+	licenses := make([]map[string]string, len(plan.Licenses))
+	for _, l := range plan.Licenses {
+		license := map[string]string{"license_type": l.LicenseType}
+		licenses = append(licenses, license)
+	}
+	d.Set("licenses", licenses)
+
+	availability_zones := make([]map[string]interface{}, len(plan.AvailabilityZones))
+	for _, az := range plan.AvailabilityZones {
+		availability_zone := make(map[string]interface{})
+		availability_zone["availability_zone"] = az.AvailabilityZone
+		availability_zone["available"] = az.Available
+		availability_zone["rank"] = az.Rank
+		availability_zones = append(availability_zones, availability_zone)
+	}
+	d.Set("availability_zones", availability_zones)
+
+	return nil
+}
+
+func getVirtualNetworkAppliancePlans(vnaClient *eclcloud.ServiceClient, listOpts appliance_plans.ListOpts) ([]appliance_plans.VirtualNetworkAppliancePlan, error) {
+	pages, err := appliance_plans.List(vnaClient, listOpts).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Load Balancer Plans: %w", err)
+	}
+
+	allPlans, err := appliance_plans.ExtractVirtualNetworkAppliancePlans(pages)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract retrieved Load Balancer Plans: %w", err)
+	}
+
+	if len(allPlans) < 1 {
+		return nil, fmt.Errorf("specified Load Balancer Plan query returned no results")
+	}
+	return allPlans, nil
+}

--- a/ecl/data_source_ecl_vna_appliance_plan_v1.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1.go
@@ -186,9 +186,9 @@ func dataSourceVNAAppliancePlanV1Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("max_number_of_aap", plan.MaxNumberOfAap)
 
 	licenses := make([]map[string]string, len(plan.Licenses))
-	for _, l := range plan.Licenses {
+	for i, l := range plan.Licenses {
 		license := map[string]string{"license_type": l.LicenseType}
-		licenses = append(licenses, license)
+		licenses[i] = license
 	}
 	d.Set("licenses", licenses)
 

--- a/ecl/data_source_ecl_vna_appliance_plan_v1.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1.go
@@ -193,12 +193,12 @@ func dataSourceVNAAppliancePlanV1Read(d *schema.ResourceData, meta interface{}) 
 	d.Set("licenses", licenses)
 
 	availability_zones := make([]map[string]interface{}, len(plan.AvailabilityZones))
-	for _, az := range plan.AvailabilityZones {
+	for i, az := range plan.AvailabilityZones {
 		availability_zone := make(map[string]interface{})
 		availability_zone["availability_zone"] = az.AvailabilityZone
 		availability_zone["available"] = az.Available
 		availability_zone["rank"] = az.Rank
-		availability_zones = append(availability_zones, availability_zone)
+		availability_zones[i] = availability_zone
 	}
 	d.Set("availability_zones", availability_zones)
 

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -61,7 +61,7 @@ func TestMockedAccVNAV1AppliancePlanDataSource_queries(t *testing.T) {
 			{
 				Config: testAccVNAV1AppliancePlanDataSourceQueryID,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_2"),
 				),
 			},
 			{

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -23,7 +23,7 @@ func TestMockedAccVNAV1AppliancePlanDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVNAV1AppliancePlanDataSourceBasic,
+				Config: testAccVNAV1AppliancePlanDataSourceQueryName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
 					resource.TestCheckResourceAttr(

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -1,0 +1,206 @@
+package ecl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/nttcom/terraform-provider-ecl/ecl/testhelper/mock"
+)
+
+func TestMockedAccVNAV1AppliancePlanDataSource_basic(t *testing.T) {
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "virtual_network_appliance_plans", "/v1.0/virtual_network_appliance_plans", testMockVNAV1AppliancePlansListNameQuery)
+
+	mc.StartServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "name", testAccVNAV1AppliancePlanDataSourcePlanName),
+				),
+			},
+		},
+	})
+}
+
+func TestMockedAccVNAV1AppliancePlanDataSource_queries(t *testing.T) {
+	mc := mock.NewMockController()
+	defer mc.TerminateMockControllerSafety()
+
+	postKeystone := fmt.Sprintf(fakeKeystonePostTmpl, mc.Endpoint(), OS_REGION_NAME)
+	mc.Register(t, "keystone", "/v3/auth/tokens", postKeystone)
+	mc.Register(t, "virtual_network_appliance_plans", "/v1.0/virtual_network_appliance_plans", testMockVNAV1AppliancePlansListNameQuery)
+	mc.Register(t, "virtual_network_appliance_plans", "/v1.0/virtual_network_appliance_plans", testMockVNAV1AppliancePlansListIDQuery)
+	mc.Register(t, "virtual_network_appliance_plans", "/v1.0/virtual_network_appliance_plans", testMockVNAV1AppliancePlansListDescriptionQuery)
+
+	mc.StartServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceQueryName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "name", testAccVNAV1AppliancePlanDataSourcePlanName),
+				),
+			},
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceQueryID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+				),
+			},
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceQueryDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+				),
+			},
+		},
+	})
+}
+
+var testMockVNAV1AppliancePlansListNameQuery = fmt.Sprintf(`
+request:
+    method: GET
+    query:
+      name:
+        - %q
+response:
+    code: 200
+    body: >
+        {
+          "virtual_network_appliance_plans": [
+            {
+              "id": "37556569-87f2-4699-b5ff-bf38e7cbf8a7",
+              "name": %q,
+              "description": "virtual_network_appliance_plans_description",
+              "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+              "version": "",
+              "flavor": "2CPU-8GB",
+              "number_of_interfaces": 8,
+              "enabled": true,
+              "max_number_of_aap": 1,
+              "licenses": [
+                {
+                  "license_type": "STD"
+                }
+              ],
+              "availability_zones": [
+                {
+                  "availability_zone": "zone1_groupa",
+                  "available": true,
+                  "rank": 1
+                },
+                {
+                  "availability_zone": "zone1_groupb",
+                  "available": false,
+                  "rank": 2
+                }
+              ]
+            }
+          ]
+        }
+`, testAccVNAV1AppliancePlanDataSourcePlanName, testAccVNAV1AppliancePlanDataSourcePlanName,
+)
+var testMockVNAV1AppliancePlansListIDQuery = fmt.Sprintf(`
+request:
+    method: GET
+    query:
+      id:
+        - 37556569-87f2-4699-b5ff-bf38e7cbf8a7
+response:
+    code: 200
+    body: >
+        {
+          "virtual_network_appliance_plans": [
+            {
+              "id": "37556569-87f2-4699-b5ff-bf38e7cbf8a7",
+              "name": %q,
+              "description": "virtual_network_appliance_plans_description",
+              "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+              "version": "",
+              "flavor": "2CPU-8GB",
+              "number_of_interfaces": 8,
+              "enabled": true,
+              "max_number_of_aap": 1,
+              "licenses": [
+                {
+                  "license_type": "STD"
+                }
+              ],
+              "availability_zones": [
+                {
+                  "availability_zone": "zone1_groupa",
+                  "available": true,
+                  "rank": 1
+                },
+                {
+                  "availability_zone": "zone1_groupb",
+                  "available": false,
+                  "rank": 2
+                }
+              ]
+            }
+          ]
+        }
+`, testAccVNAV1AppliancePlanDataSourcePlanName,
+)
+
+var testMockVNAV1AppliancePlansListDescriptionQuery = fmt.Sprintf(`
+request:
+    method: GET
+    query:
+      id:
+        - virtual_network_appliance_plans_description
+response:
+    code: 200
+    body: >
+        {
+          "virtual_network_appliance_plans": [
+            {
+              "id": "37556569-87f2-4699-b5ff-bf38e7cbf8a7",
+              "name": %q,
+              "description": "virtual_network_appliance_plans_description",
+              "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
+              "version": "",
+              "flavor": "2CPU-8GB",
+              "number_of_interfaces": 8,
+              "enabled": true,
+              "max_number_of_aap": 1,
+              "licenses": [
+                {
+                  "license_type": "STD"
+                }
+              ],
+              "availability_zones": [
+                {
+                  "availability_zone": "zone1_groupa",
+                  "available": true,
+                  "rank": 1
+                },
+                {
+                  "availability_zone": "zone1_groupb",
+                  "available": false,
+                  "rank": 2
+                }
+              ]
+            }
+          ]
+        }
+`, testAccVNAV1AppliancePlanDataSourcePlanName,
+)

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -204,5 +204,5 @@ response:
             }
           ]
         }
-`, testAccVNAV1AppliancePlanDataSourcePlanName,
+`, testAccVNAV1AppliancePlanDataSourcePlanName, testAccVNAV1AppliancePlanDataSourcePlanName, testAccVNAV1AppliancePlanDataSourcePlanName,
 )

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -68,6 +68,8 @@ func TestMockedAccVNAV1AppliancePlanDataSource_queries(t *testing.T) {
 				Config: testAccVNAV1AppliancePlanDataSourceQueryDescription,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "description", testAccVNAV1AppliancePlanDataSourcePlanName),
 				),
 			},
 		},

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -165,8 +165,8 @@ var testMockVNAV1AppliancePlansListDescriptionQuery = fmt.Sprintf(`
 request:
     method: GET
     query:
-      id:
-        - virtual_network_appliance_plans_description
+      description:
+        - %q
 response:
     code: 200
     body: >

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_mock_test.go
@@ -177,7 +177,7 @@ response:
             {
               "id": "37556569-87f2-4699-b5ff-bf38e7cbf8a7",
               "name": %q,
-              "description": "virtual_network_appliance_plans_description",
+              "description": %q,
               "appliance_type": "ECL::VirtualNetworkAppliance::VSRX",
               "version": "",
               "flavor": "2CPU-8GB",

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
@@ -107,7 +107,7 @@ data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
   name = %q
 }
 data "ecl_vna_appliance_plan_v1" "appliance_plan_2" {
-  id = "${data.ecl_network_appliance_plan_v1.appliance_plan_1.id}"
+  id = "${data.ecl_vna_appliance_plan_v1.appliance_plan_1.id}"
 }
 `, testAccVNAV1AppliancePlanDataSourcePlanName,
 )

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
@@ -26,7 +26,7 @@ func TestAccVNAV1AppliancePlanDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "appliance_type", "ECL::VirtualNetworkAppliance::VSRX"),
 					resource.TestCheckResourceAttr(
-						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "flavor", "2CPU-8GB"),
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "flavor", "2CPU-4GB"),
 					resource.TestCheckResourceAttr(
 						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "enabled", "true"),
 					resource.TestCheckResourceAttr(

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
@@ -34,7 +34,7 @@ func TestAccVNAV1AppliancePlanDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "licenses.0.license_type", "STD"),
 					resource.TestCheckResourceAttr(
-						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.#", "1"),
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.#", "3"),
 					resource.TestCheckResourceAttr(
 						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.0.availability_zone", "zone1_groupa"),
 					resource.TestCheckResourceAttr(

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
@@ -1,0 +1,127 @@
+package ecl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const testAccVNAV1AppliancePlanDataSourcePlanName = "vSRX_20.4R2_2CPU_4GB_8IF_STD"
+
+func TestAccVNAV1AppliancePlanDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "name", testAccVNAV1AppliancePlanDataSourcePlanName),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "description", testAccVNAV1AppliancePlanDataSourcePlanName),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "appliance_type", "ECL::VirtualNetworkAppliance::VSRX"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "flavor", "2CPU-8GB"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "licenses.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "licenses.0.license_type", "STD"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.0.availability_zone", "zone1_groupa"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.0.available", "true"),
+					resource.TestCheckResourceAttr(
+						"data.ecl_vna_appliance_plan_v1.appliance_plan_1", "availability_zones.0.rank", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVNAV1AppliancePlanDataSource_queries(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceQueryName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_1"),
+				),
+			},
+			{
+				Config: testAccVNAV1AppliancePlanDataSourceQueryID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVNAV1AppliancePlanDataSourceID("data.ecl_vna_appliance_plan_v1.appliance_plan_2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVNAV1AppliancePlanDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find vna_appliance_plan data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("vna plan data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+var testAccVNAV1AppliancePlanDataSourceBasic = fmt.Sprintf(`
+data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
+  name = %q
+  description = %q
+  appliance_type = "ECL::VirtualNetworkAppliance::VSRX"
+  flavor = "2CPU-8GB"
+  enabled = true
+  licenses {
+    license_type = "STD"
+  }
+  availability_zones {
+    availability_zone = "zone1_groupa"
+    available = true
+    rank = 1
+  }
+}
+`, testAccVNAV1AppliancePlanDataSourcePlanName, testAccVNAV1AppliancePlanDataSourcePlanName,
+)
+
+var testAccVNAV1AppliancePlanDataSourceQueryID = fmt.Sprintf(`
+data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
+  name = %q
+}
+data "ecl_vna_appliance_plan_v1" "appliance_plan_2" {
+  id = "${data.ecl_network_appliance_plan_v1.appliance_plan_1.id}"
+}
+`, testAccVNAV1AppliancePlanDataSourcePlanName,
+)
+
+var testAccVNAV1AppliancePlanDataSourceQueryName = fmt.Sprintf(`
+data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
+  name = %q
+}
+`, testAccVNAV1AppliancePlanDataSourcePlanName,
+)
+
+var testAccVNAV1AppliancePlanDataSourceQueryDescription = fmt.Sprintf(`
+data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
+  description = %q
+}
+`, testAccVNAV1AppliancePlanDataSourcePlanName,
+)

--- a/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
+++ b/ecl/data_source_ecl_vna_appliance_plan_v1_test.go
@@ -88,7 +88,7 @@ data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
   name = %q
   description = %q
   appliance_type = "ECL::VirtualNetworkAppliance::VSRX"
-  flavor = "2CPU-8GB"
+  flavor = "2CPU-4GB"
   enabled = true
   licenses {
     license_type = "STD"

--- a/ecl/provider.go
+++ b/ecl/provider.go
@@ -203,6 +203,7 @@ func Provider() terraform.ResourceProvider {
 			"ecl_storage_volume_v1":                  dataSourceStorageVolumeV1(),
 			"ecl_storage_volumetype_v1":              dataSourceStorageVolumeTypeV1(),
 			"ecl_vna_appliance_v1":                   dataSourceVNAApplianceV1(),
+			"ecl_vna_appliance_plan_v1":              dataSourceVNAAppliancePlanV1(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nttcom/terraform-provider-ecl
 
 require (
 	github.com/hashicorp/terraform v0.12.6
-	github.com/nttcom/eclcloud/v2 v2.2.0
+	github.com/nttcom/eclcloud/v2 v2.3.0
 	github.com/unknwon/com v0.0.0-20190804042917-757f69c95f3e
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/nttcom/eclcloud/v2 v2.2.0 h1:5ePTK8lJPO2WQolFLb1P7i8kLVkmDf7w9TIHvprWrvs=
-github.com/nttcom/eclcloud/v2 v2.2.0/go.mod h1:KoBB1B+xdeRXo0fNzggINrTQiuAsezh1SBVcbryS348=
+github.com/nttcom/eclcloud/v2 v2.3.0 h1:TqAT2m3jzWiwxoK9wu9SXHzpxCfMp06NTU3HlYVwHO4=
+github.com/nttcom/eclcloud/v2 v2.3.0/go.mod h1:KoBB1B+xdeRXo0fNzggINrTQiuAsezh1SBVcbryS348=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/doc.go
+++ b/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/doc.go
@@ -1,0 +1,37 @@
+/*
+Package appliance_plans contains functionality for working with
+ECL Virtual Network Appliance Plan resources.
+
+Example to List Virtual Network Appliance Plans
+
+	listOpts := appliance_plans.ListOpts{
+		Description: "general",
+	}
+
+	allPages, err := appliance_plans.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allVirtualNetworkAppliancePlans, err := appliance_plans.ExtractVirtualNetworkAppliancePlans(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, virtualNetworkAppliancePlan := range allVirtualNetworkAppliancePlans {
+		fmt.Printf("%+v\n", virtualNetworkAppliancePlan)
+	}
+
+Example to Show Virtual Network Appliance Plan
+
+	virtualNetworkAppliancePlanID := "37556569-87f2-4699-b5ff-bf38e7cbf8a7"
+
+	virtualNetworkAppliancePlan, err := appliance_plans.Get(networkClient, virtualNetworkAppliancePlanID, nil).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", virtualNetworkAppliancePlan)
+
+*/
+package appliance_plans

--- a/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/requests.go
@@ -1,0 +1,111 @@
+package appliance_plans
+
+import (
+	"github.com/nttcom/eclcloud/v2"
+	"github.com/nttcom/eclcloud/v2/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Virtual Network Appliance Plan attributes you want to see returned.
+type ListOpts struct {
+	ID                        string `q:"id"`
+	Name                      string `q:"name"`
+	Description               string `q:"description"`
+	ApplianceType             string `q:"appliance_type"`
+	Version                   string `q:"version"`
+	Flavor                    string `q:"flavor"`
+	NumberOfInterfaces        int    `q:"number_of_interfaces"`
+	Enabled                   bool   `q:"enabled"`
+	MaxNumberOfAap            int    `q:"max_number_of_aap"`
+	Details                   bool   `q:"details"`
+	AvailabilityZone          string `q:"availability_zone"`
+	AvailabilityZoneAvailable bool   `q:"availability_zone.available"`
+}
+
+// ToVirtualNetworkAppliancePlanListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVirtualNetworkAppliancePlanListQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// Virtual Network Appliance Plans. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *eclcloud.ServiceClient, opts ListOpts) pagination.Pager {
+	url := listURL(c)
+	query, err := opts.ToVirtualNetworkAppliancePlanListQuery()
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	url += query
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return VirtualNetworkAppliancePlanPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// GetOptsBuilder allows extensions to add additional parameters to
+// the Virtual Network Appliance Plan API request
+type GetOptsBuilder interface {
+	ToProcessQuery() (string, error)
+}
+
+// GetOpts represents result of Virtual Network Appliance Plan API response.
+type GetOpts struct {
+	VirtualNetworkAppliancePlanId string `q:"virtual_network_appliance_plan_id"`
+	Details                       bool   `q:"details"`
+}
+
+// ToProcessQuery formats a GetOpts into a query string.
+func (opts GetOpts) ToProcessQuery() (string, error) {
+	q, err := eclcloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Get retrieves a specific Virtual Network Appliance Plan based on its unique ID.
+func Get(c *eclcloud.ServiceClient, id string, opts GetOptsBuilder) (r GetResult) {
+	url := getURL(c, id)
+	if opts != nil {
+		query, _ := opts.ToProcessQuery()
+		url += query
+	}
+	_, r.Err = c.Get(url, &r.Body, nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a Virtual Network Appliance Plan's ID,
+// given its name.
+func IDFromName(client *eclcloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractVirtualNetworkAppliancePlans(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", eclcloud.ErrResourceNotFound{Name: name, ResourceType: "virtual_network_appliance_plan"}
+	case 1:
+		return id, nil
+	default:
+		return "", eclcloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "virtual_network_appliance_plan"}
+	}
+}

--- a/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/results.go
+++ b/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/results.go
@@ -1,0 +1,98 @@
+package appliance_plans
+
+import (
+	"github.com/nttcom/eclcloud/v2"
+	"github.com/nttcom/eclcloud/v2/pagination"
+)
+
+type commonResult struct {
+	eclcloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Virtual Network Appliance Plan resource.
+func (r commonResult) Extract() (*VirtualNetworkAppliancePlan, error) {
+	var s struct {
+		VirtualNetworkAppliancePlan *VirtualNetworkAppliancePlan `json:"virtual_network_appliance_plan"`
+	}
+	err := r.ExtractInto(&s)
+	return s.VirtualNetworkAppliancePlan, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Virtual Network Appliance Plan.
+type GetResult struct {
+	commonResult
+}
+
+// License of Virtual Network Appliance
+type License struct {
+	LicenseType string `json:"license_type"`
+}
+
+// Availability Zone of Virtual Network Appliance
+type AvailabilityZone struct {
+	AvailabilityZone string `json:"availability_zone"`
+	Available        bool   `json:"available"`
+	Rank             int    `json:"rank"`
+}
+
+// VirtualNetworkAppliancePlan represents a Virtual Network Appliance Plan.
+// See package documentation for a top-level description of what this is.
+type VirtualNetworkAppliancePlan struct {
+
+	// UUID representing the Virtual Network Appliance Plan.
+	ID string `json:"id"`
+
+	// Name of the Virtual Network Appliance Plan.
+	Name string `json:"name"`
+
+	// Description is description
+	Description string `json:"description"`
+
+	// Type of appliance
+	ApplianceType string `json:"appliance_type"`
+
+	// Version name
+	Version string `json:"version"`
+
+	// Nova flavor
+	Flavor string `json:"flavor"`
+
+	// Number of Interfaces
+	NumberOfInterfaces int `json:"number_of_interfaces"`
+
+	// Is user allowed to create new firewalls with this plan.
+	Enabled bool `json:"enabled"`
+
+	// Max Number of allowed_address_pairs
+	MaxNumberOfAap int `json:"max_number_of_aap"`
+
+	// Licenses
+	Licenses []License `json:"licenses"`
+
+	// AvailabilityZones
+	AvailabilityZones []AvailabilityZone `json:"availability_zones"`
+}
+
+// VirtualNetworkAppliancePlanPage is the page returned by a pager when traversing over a collection
+// of virtual network appliance plans.
+type VirtualNetworkAppliancePlanPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a VirtualNetworkAppliancePlanPage struct is empty.
+func (r VirtualNetworkAppliancePlanPage) IsEmpty() (bool, error) {
+	is, err := ExtractVirtualNetworkAppliancePlans(r)
+	return len(is) == 0, err
+}
+
+// ExtractVirtualNetworkAppliancePlans accepts a Page struct, specifically a VirtualNetworkAppliancePlanPage struct,
+// and extracts the elements into a slice of Virtual Network Appliance Plan structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractVirtualNetworkAppliancePlans(r pagination.Page) ([]VirtualNetworkAppliancePlan, error) {
+	var s struct {
+		VirtualNetworkAppliancePlans []VirtualNetworkAppliancePlan `json:"virtual_network_appliance_plans"`
+	}
+	err := (r.(VirtualNetworkAppliancePlanPage)).ExtractInto(&s)
+	return s.VirtualNetworkAppliancePlans, err
+}

--- a/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/urls.go
+++ b/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans/urls.go
@@ -1,0 +1,19 @@
+package appliance_plans
+
+import "github.com/nttcom/eclcloud/v2"
+
+func resourceURL(c *eclcloud.ServiceClient, id string) string {
+	return c.ServiceURL("virtual_network_appliance_plans", id)
+}
+
+func rootURL(c *eclcloud.ServiceClient) string {
+	return c.ServiceURL("virtual_network_appliance_plans")
+}
+
+func listURL(c *eclcloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *eclcloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -204,7 +204,7 @@ github.com/mitchellh/hashstructure
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
-# github.com/nttcom/eclcloud/v2 v2.2.0
+# github.com/nttcom/eclcloud/v2 v2.3.0
 ## explicit
 github.com/nttcom/eclcloud/v2
 github.com/nttcom/eclcloud/v2/ecl
@@ -264,6 +264,7 @@ github.com/nttcom/eclcloud/v2/ecl/storage/v1/virtualstorages
 github.com/nttcom/eclcloud/v2/ecl/storage/v1/volumes
 github.com/nttcom/eclcloud/v2/ecl/storage/v1/volumetypes
 github.com/nttcom/eclcloud/v2/ecl/utils
+github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliance_plans
 github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliances
 github.com/nttcom/eclcloud/v2/internal
 github.com/nttcom/eclcloud/v2/pagination

--- a/website/docs/d/vna_appliance_plan_v1.html.markdown
+++ b/website/docs/d/vna_appliance_plan_v1.html.markdown
@@ -48,7 +48,6 @@ data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
 
 `id` is set to the ID of the found VNA Plan. In addition, the following attributes are exported:
 
-* `id` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `appliance_type` - See Argument Reference above.

--- a/website/docs/d/vna_appliance_plan_v1.html.markdown
+++ b/website/docs/d/vna_appliance_plan_v1.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "ecl"
+page_title: "Enterprise Cloud: ecl_vna_appliance_plan_v1"
+sidebar_current: "docs-ecl-datasource-vna-appliance_plan-v1"
+description: |-
+  Get information on an Enterprise Cloud VNA Plan.
+---
+
+# ecl\_vna\_appliance\_plan\_v1
+
+Use this data source to get the ID and Details of an Enterprise Cloud VNA Plan.
+
+## Example Usage
+
+```hcl
+data "ecl_vna_appliance_plan_v1" "appliance_plan_1" {
+  name = "vSRX_20.4R2_2CPU_4GB_8IF_STD"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) ID of the Virtual Network Appliance Plan
+
+* `name` - (Optional) Name of the Virtual Network Appliance Plan
+
+* `description` - (Optional) Description of the Virtual Network Appliance Plan
+
+* `appliance_type` - (Optional) Type of appliance
+
+* `version` - (Optional) Version of the Virtual Network Appliance Plan
+
+* `flavor` - (Optional) Nova flavor
+
+* `number_of_interfaces` - (Optional) Number of Interfaces
+
+* `enabled` - (Optional) Is user allowed to create new firewalls with this plan.
+
+* `max_number_of_aap` - (Optional) Max Number of allowed\_address\_pairs
+
+* `details` - (Optional) If details is false, availability\_zones is not displayed.
+
+* `availability_zone` - (Optional) Availability zones of the Virtual Network Appliance Plan
+
+* `availability_zone.available` - (Optional) Display only the Virtual Network Appliance Plan including available=X in the array of availability_zones and stores only the availability_zone including available=X in the array of availability_zones.
+
+## Attributes Reference
+
+`id` is set to the ID of the found VNA Plan. In addition, the following attributes are exported:
+
+* `id` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `appliance_type` - See Argument Reference above.
+* `version` - See Argument Reference above.
+* `flavor` - See Argument Reference above.
+* `number_of_interfaces` - See Argument Reference above.
+* `enabled` - See Argument Reference above.
+* `max_number_of_aap` - See Argument Reference above.
+
+* `licenses/license_type` - Type of license
+
+* `availability_zones/availability_zone` - Availability\_zones of the Virtual Network Appliance Plan
+* `availability_zones/available` - Availability\_zones availability
+* `availability_zones/rank` - The rank is displayed in the order of decreasing the quantity of Virtual Network Appliance resources.


### PR DESCRIPTION
This is a commit corresponding to [eclcloud#38](https://github.com/nttcom/eclcloud/pull/38).
The user will be able to create a VNA by indicating some of plan's attribute like `id` and `name`.

This PR includes follows.
- Add `ecl_vna_appliance_plan_v1` data type
- Add a related document
- Add tests

Ref:
https://sdpf.ntt.com/services/docs/firewall/api-references/rsts/APIList/source/list_virtual_network_appliance_plan.html