### PR TITLE
Retrieve credentials on VNA creation

### DIFF
--- a/ecl/resource_ecl_vna_appliance_v1.go
+++ b/ecl/resource_ecl_vna_appliance_v1.go
@@ -159,6 +159,16 @@ func resourceVNAApplianceV1() *schema.Resource {
 				Optional: true,
 			},
 
+			"username": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"default_gateway": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -231,6 +241,8 @@ func resourceVNAApplianceV1Create(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(vna.ID)
+	d.Set("username", vna.Username)
+	d.Set("password", vna.Password)
 	log.Printf("[INFO] Virtual Network Appliance ID: %s", vna.ID)
 	log.Printf("[DEBUG] Waiting for Virtual Network Appliance (%s) to become COMPLETE", vna.ID)
 

--- a/ecl/resource_ecl_vna_appliance_v1_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_test.go
@@ -323,6 +323,7 @@ func TestAccVNAV1Appliance_createInterfaceDiscontinuity(t *testing.T) {
 
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "name", "appliance_1"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "description", "appliance_1_description"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "username", "root"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "virtual_network_appliance_plan_id", OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_3_info.0.name", "interface_3"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_3_info.0.description", "interface_3_description"),
@@ -368,6 +369,7 @@ func TestAccVNAV1Appliance_createNoInterface(t *testing.T) {
 
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "name", "appliance_1"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "description", "appliance_1_description"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "username", "root"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "virtual_network_appliance_plan_id", OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID),
 					testAccCheckVNAV1FixedIPLength(&vna, 1, 0),
 					testAccCheckVNAV1FixedIPLength(&vna, 2, 0),
@@ -407,6 +409,7 @@ func TestAccVNAV1Appliance_createFixedIPsEmpty(t *testing.T) {
 
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "name", "appliance_1"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "description", "appliance_1_description"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "username", "root"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "virtual_network_appliance_plan_id", OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.name", "interface_1"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.description", "interface_1_description"),
@@ -449,6 +452,7 @@ func TestAccVNAV1Appliance_createNoFixedIPs(t *testing.T) {
 
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "name", "appliance_1"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "description", "appliance_1_description"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "username", "root"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "virtual_network_appliance_plan_id", OS_VIRTUAL_NETWORK_APPLIANCE_PLAN_ID),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.name", "interface_1"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.description", "interface_1_description"),
@@ -798,6 +802,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -848,6 +854,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -871,6 +879,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -904,6 +914,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -936,6 +948,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -999,6 +1013,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1064,6 +1080,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1108,6 +1126,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1142,6 +1162,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1178,6 +1200,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1217,11 +1241,13 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		ip_address = "192.168.1.200"
 		mac_address = ""
 		type = "vrrp"
-		vrid = "123"	
+		vrid = "123"
 	}
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1260,11 +1286,13 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		ip_address = "192.168.1.200"
 		mac_address = "aa:bb:cc:dd:ee:f1"
 		type = ""
-		vrid = "null"	
+		vrid = "null"
 	}
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1303,6 +1331,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1345,9 +1375,11 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	interface_2_info  {
 		network_id = "${ecl_network_network_v2.network_2.id}"
 	}
-	
+
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}
@@ -1391,9 +1423,11 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	interface_2_info  {
 		network_id = ""
 	}
-	
+
 	lifecycle {
 		ignore_changes = [
+			"username",
+			"password",
 			"default_gateway",
 		]
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nttcom/terraform-provider-ecl
 
 require (
 	github.com/hashicorp/terraform v0.12.6
-	github.com/nttcom/eclcloud/v2 v2.3.0
+	github.com/nttcom/eclcloud/v2 v2.3.1
 	github.com/unknwon/com v0.0.0-20190804042917-757f69c95f3e
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/nttcom/eclcloud/v2 v2.3.0 h1:TqAT2m3jzWiwxoK9wu9SXHzpxCfMp06NTU3HlYVwHO4=
-github.com/nttcom/eclcloud/v2 v2.3.0/go.mod h1:KoBB1B+xdeRXo0fNzggINrTQiuAsezh1SBVcbryS348=
+github.com/nttcom/eclcloud/v2 v2.3.1 h1:zJflSf0QFgAAy6yOsSLDpxpRhthAACA4/PRugQ+kp4k=
+github.com/nttcom/eclcloud/v2 v2.3.1/go.mod h1:KoBB1B+xdeRXo0fNzggINrTQiuAsezh1SBVcbryS348=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliances/results.go
+++ b/vendor/github.com/nttcom/eclcloud/v2/ecl/vna/v1/appliances/results.go
@@ -101,6 +101,8 @@ type Appliance struct {
 	OperationStatus    string               `json:"operation_status"`
 	AppliancePlanID    string               `json:"virtual_network_appliance_plan_id"`
 	TenantID           string               `json:"tenant_id"`
+	Username           string               `json:"username"`
+	Password           string               `json:"password"`
 	Tags               map[string]string    `json:"tags"`
 	Interfaces         InterfacesInResponse `json:"interfaces"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -204,7 +204,7 @@ github.com/mitchellh/hashstructure
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
-# github.com/nttcom/eclcloud/v2 v2.3.0
+# github.com/nttcom/eclcloud/v2 v2.3.1
 ## explicit
 github.com/nttcom/eclcloud/v2
 github.com/nttcom/eclcloud/v2/ecl

--- a/website/docs/r/vna_appliance_v1.html.markdown
+++ b/website/docs/r/vna_appliance_v1.html.markdown
@@ -317,6 +317,10 @@ The following attributes are exported:
 
 * `tenant_id` - See Argument Reference above.
 
+* `username` - Username with user access to VNA instance
+
+* `password` - Password for user
+
 * `interface_[slot number]_info/updatable` - See Argument Reference above.
 
 * `interface_[slot number]_info/tags` - See Argument Reference above.


### PR DESCRIPTION
This is a PR that corresponds to [eclcloud#39](https://github.com/nttcom/eclcloud/pull/39) to include initial password on VNA resources.

This includes:
- Add attributes for `ecl_vna_appliance_v1` resource
- Update related documents
- Update eclcloud module to v2.3.1