### PR TITLE
:bug: IF-9595 Fix Example Usage of destination with ecl_network_static_route_v2

### DIFF
--- a/ecl/data_source_ecl_network_static_route_v2_test.go
+++ b/ecl/data_source_ecl_network_static_route_v2_test.go
@@ -149,7 +149,7 @@ resource "ecl_network_public_ip_v2" "public_ip_1" {
 
 resource "ecl_network_static_route_v2" "static_route_1" {
     description = "test_static_route1"
-    destination = "${ecl_network_public_ip_v2.public_ip_1.cidr}"
+    destination = "${ecl_network_public_ip_v2.public_ip_1.cidr}/${ecl_network_public_ip_v2.public_ip_1.submask_length}"
     internet_gw_id = "${ecl_network_internet_gateway_v2.internet_gateway_1.id}"
     name = "Terraform_Test_Static_Route_01"
     nexthop = "192.168.200.1"
@@ -188,7 +188,7 @@ var testAccNetworkV2StaticRouteDataSourceDestination = fmt.Sprintf(`
 %s
 
 data "ecl_network_static_route_v2" "static_route_1" {
-    destination = "${ecl_network_public_ip_v2.public_ip_1.cidr}"
+    destination = "${ecl_network_public_ip_v2.public_ip_1.cidr}/${ecl_network_public_ip_v2.public_ip_1.submask_length}"
 }
 `, testAccNetworkV2StaticRouteDataSourceStaticRoute)
 

--- a/examples/app-with-networking-and-storage/internet.tf
+++ b/examples/app-with-networking-and-storage/internet.tf
@@ -32,7 +32,7 @@ resource "ecl_network_public_ip_v2" "public_ip_2" {
 resource "ecl_network_static_route_v2" "static_route_1" {
   name           = "static_route_1"
   internet_gw_id = ecl_network_internet_gateway_v2.internet_gateway_1.id
-  destination    = ecl_network_public_ip_v2.public_ip_1.cidr
+  destination    = format("%s/%#v", ecl_network_public_ip_v2.public_ip_1.cidr, ecl_network_public_ip_v2.public_ip_1.submask_length)
   nexthop        = "192.168.1.1"
   service_type   = "internet"
 

--- a/website/docs/r/network_static_route_v2.html.markdown
+++ b/website/docs/r/network_static_route_v2.html.markdown
@@ -18,7 +18,7 @@ Manages a V2 static route resource within Enterprise Cloud.
 ```hcl
 resource "ecl_network_static_route_v2" "static_route_1" {
   description    = "test_static_route1"
-  destination    = ecl_network_public_ip_v2.public_ip_1.cidr
+  destination    = format("%s/%#v", ecl_network_public_ip_v2.public_ip_1.cidr, ecl_network_public_ip_v2.public_ip_1.submask_length)
   internet_gw_id = ecl_network_internet_gateway_v2.internet_gateway_1.id
   name           = "Terraform_Test_Static_Route_01"
   nexthop        = "192.168.200.1"


### PR DESCRIPTION
* ecl/data_source_ecl_network_static_route_v2_test.go
  - destinationにCIDRとしてサブネットマスクも指定するよう修正
* examples/app-with-networking-and-storage/internet.tf
  - destinationにCIDRとしてサブネットマスクも指定するよう修正
* website/docs/r/network_static_route_v2.html.markdown
  - destinationにCIDRとしてサブネットマスクも指定するよう修正