### PR TITLE
IF-8978 delete visibility default value of Image

### DIFF
--- a/ecl/data_source_ecl_imagestorages_image_v2_test.go
+++ b/ecl/data_source_ecl_imagestorages_image_v2_test.go
@@ -118,6 +118,7 @@ resource "ecl_imagestorages_image_v2" "image_1" {
     foo = "bar"
     bar = "foo"
   }
+  visibility = "private"
 }
 
 `, localFileForDataSourceTest)

--- a/ecl/resource_ecl_imagestorages_image_v2.go
+++ b/ecl/resource_ecl_imagestorages_image_v2.go
@@ -114,7 +114,7 @@ func resourceImageStoragesImageV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: resourceImageStoragesImageV2ValidateVisibility,
-				Computed: true,
+				Computed:     true,
 			},
 
 			"properties": &schema.Schema{

--- a/ecl/resource_ecl_imagestorages_image_v2.go
+++ b/ecl/resource_ecl_imagestorages_image_v2.go
@@ -114,7 +114,7 @@ func resourceImageStoragesImageV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: resourceImageStoragesImageV2ValidateVisibility,
-				Default:      "private",
+				Computed: true,
 			},
 
 			"properties": &schema.Schema{
@@ -194,13 +194,16 @@ func resourceImageStoragesImageV2Create(d *schema.ResourceData, meta interface{}
 		MinRAM:          d.Get("min_ram_mb").(int),
 		LicenseSwitch:   d.Get("license_switch").(string),
 		Protected:       &protected,
-		Visibility:      &visibility,
 		Properties:      imageProperties,
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
 		tags := v.(*schema.Set).List()
 		createOpts.Tags = resourceImageStoragesImageV2BuildTags(tags)
+	}
+
+	if visibility != "" {
+		createOpts.Visibility = &visibility
 	}
 
 	d.Partial(true)

--- a/ecl/resource_ecl_imagestorages_image_v2_test.go
+++ b/ecl/resource_ecl_imagestorages_image_v2_test.go
@@ -39,6 +39,8 @@ func TestAccImageStoragesV2Image_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_imagestorages_image_v2.image_1", "disk_format", "qcow2"),
 					resource.TestCheckResourceAttr(
+						"ecl_imagestorages_image_v2.image_1", "visibility", "shared"),
+					resource.TestCheckResourceAttr(
 						"ecl_imagestorages_image_v2.image_1", "schema", "/v2/schemas/image"),
 				),
 			},

--- a/ecl/resource_ecl_imagestorages_image_v2_test.go
+++ b/ecl/resource_ecl_imagestorages_image_v2_test.go
@@ -39,8 +39,6 @@ func TestAccImageStoragesV2Image_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ecl_imagestorages_image_v2.image_1", "disk_format", "qcow2"),
 					resource.TestCheckResourceAttr(
-						"ecl_imagestorages_image_v2.image_1", "visibility", "shared"),
-					resource.TestCheckResourceAttr(
 						"ecl_imagestorages_image_v2.image_1", "schema", "/v2/schemas/image"),
 				),
 			},

--- a/website/docs/r/imagestorages_image_v2.html.markdown
+++ b/website/docs/r/imagestorages_image_v2.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `verify_checksum` - (Optional) If false, the checksum will not be verified once the image is finished uploading. Defaults to true.
 
-* `visibility` - (Optional) Scope of image accessibility. Must be one of "public", "private". Defaults to "private".
+* `visibility` - (Optional) Scope of image accessibility. Must be one of "public", "private", "shared".
 
 * `peroperties` - (Optional) A map of key/value pairs to set freeform information about an image.
 


### PR DESCRIPTION
### Overview
Delete the default value of visibility for Image

### Description of the Change
- ecl/data_source_ecl_imagestorages_image_v2_test.go
    - The test also validates the visibility value, but if visibility is not specified at the time of resource creation, the visibility value changes for each location and the test fails. Therefore, it was modified to specify "private".
- ecl/resource_ecl_imagestorages_image_v2.go
    - Delete default value of visibility
    - Add computed specification so that resources are automatically calculated.
    - Fix to specify value only when visibility is empty.
- website/docs/r/imagestorages_image_v2.html.markdown
    - Add shared of visibility