### PR TITLE
VNF-3111 add initial config

### DIFF
--- a/ecl/resource_ecl_vna_appliance_v1.go
+++ b/ecl/resource_ecl_vna_appliance_v1.go
@@ -129,6 +129,26 @@ func interfaceInfoSchema() *schema.Schema {
 	}
 }
 
+func initialConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"format": &schema.Schema{
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"data": &schema.Schema{
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
 func resourceVNAApplianceV1() *schema.Resource {
 	var result *schema.Resource
 
@@ -211,6 +231,8 @@ func resourceVNAApplianceV1() *schema.Resource {
 		result.Schema[fmt.Sprintf("interface_%d_no_allowed_address_pairs", i)] = noAllowedAddressPairsSchema(i)
 	}
 
+	result.Schema["initial_config"] = initialConfigSchema()
+
 	return result
 }
 
@@ -231,6 +253,7 @@ func resourceVNAApplianceV1Create(d *schema.ResourceData, meta interface{}) erro
 			TenantID:                      d.Get("tenant_id").(string),
 			Tags:                          resourceTags(d),
 			Interfaces:                    getInterfaceCreateOpts(d),
+			InitialConfig:                 getInitialConfigCreateOpts(d),
 		},
 	}
 

--- a/ecl/resource_ecl_vna_appliance_v1.go
+++ b/ecl/resource_ecl_vna_appliance_v1.go
@@ -139,6 +139,9 @@ func initialConfigSchema() *schema.Schema {
 				"format": &schema.Schema{
 					Type:     schema.TypeString,
 					Required: true,
+					ValidateFunc: validation.StringInSlice(
+						[]string{"set", "text"}, false,
+					),
 				},
 				"data": &schema.Schema{
 					Type:     schema.TypeString,

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -370,6 +370,8 @@ func TestMockedAccVNAV1Appliance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.description", "interface_1_description"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.network_id", "dummyNetworkID"),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_fixed_ips.0.ip_address", "192.168.1.50"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "initial_config.format", "set"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "initial_config.data", "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"),
 				),
 			},
 		},
@@ -427,9 +429,16 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		ip_address = "192.168.1.50"
 	}
 
+    initial_config = {
+        format = "set"
+        data = "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
+    }
+
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -467,6 +476,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -485,6 +496,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -511,6 +524,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
     lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -535,6 +550,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
     lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -577,6 +594,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
     lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -614,6 +633,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -642,6 +663,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -692,6 +715,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
     lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,
@@ -2587,6 +2612,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
+            "username",
+            "password",
 		]
 	}
 }`,

--- a/ecl/resource_ecl_vna_appliance_v1_mock_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_mock_test.go
@@ -419,26 +419,26 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1"
 		description = "interface_1_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
 	interface_1_fixed_ips {
 		ip_address = "192.168.1.50"
 	}
 
-    initial_config = {
-        format = "set"
-        data = "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
-    }
+	initial_config = {
+		format = "set"
+		data = "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
+	}
 
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -454,20 +454,20 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_3_info  {
+	interface_3_info  {
 		name = "interface_3"
 		description = "interface_3_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
 	interface_3_fixed_ips {
 		ip_address = "192.168.1.53"
 	}
 
-    interface_8_info  {
+	interface_8_info  {
 		name = "interface_8"
 		description = "interface_8_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
 	interface_8_fixed_ips {
@@ -476,8 +476,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -496,8 +496,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -513,19 +513,19 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1"
 		description = "interface_1_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
-    interface_1_no_fixed_ips = "true"
+	interface_1_no_fixed_ips = "true"
 
-    lifecycle {
+	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -541,17 +541,17 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1"
 		description = "interface_1_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
-    lifecycle {
+	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -567,10 +567,10 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1"
 		description = "interface_1_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
 	interface_1_fixed_ips {
@@ -591,11 +591,11 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		vrid = "null"
 	}
 
-    lifecycle {
+	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -611,19 +611,19 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    tags = {
-        k1 = "v1"
-        k2 = "v2"
-    }
+	tags = {
+		k1 = "v1"
+		k2 = "v2"
+	}
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1-update"
 		description = "interface_1_description-update"
-        network_id = "dummyNetworkID"
-        tags = {
-            interfaceK1 = "interfaceV1"
-            interfaceK2 = "interfaceV2"
-        }
+		network_id = "dummyNetworkID"
+		tags = {
+			interfaceK1 = "interfaceV1"
+			interfaceK2 = "interfaceV2"
+		}
 	}
 
 	interface_1_fixed_ips {
@@ -633,8 +633,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -650,10 +650,10 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1-update"
 		description = "interface_1_description-update"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
 	interface_1_fixed_ips {
@@ -663,8 +663,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -680,43 +680,43 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	availability_zone = "%s"
 	virtual_network_appliance_plan_id = "%s"
 
-    interface_1_info  {
+	interface_1_info  {
 		name = "interface_1"
 		description = "interface_1_description"
-        network_id = "dummyNetworkID"
+		network_id = "dummyNetworkID"
 	}
 
 	interface_1_fixed_ips {
 		ip_address = "192.168.1.50"
 	}
 
-    interface_2_info  {
-        network_id = "dummyNetworkID2"
+	interface_2_info  {
+		network_id = "dummyNetworkID2"
 	}
 
-    interface_3_info  {
-        network_id = "dummyNetworkID3"
+	interface_3_info  {
+		network_id = "dummyNetworkID3"
 	}
 
-    interface_3_fixed_ips {
+	interface_3_fixed_ips {
 		ip_address = "192.168.3.50"
 	}
 
-    interface_3_fixed_ips {
+	interface_3_fixed_ips {
 		ip_address = "192.168.3.60"
 	}
 
-    interface_4_info  {
-        network_id = "dummyNetworkID4"
+	interface_4_info  {
+		network_id = "dummyNetworkID4"
 	}
 
-    interface_4_no_fixed_ips = "true"
+	interface_4_no_fixed_ips = "true"
 
-    lifecycle {
+	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,
@@ -2612,8 +2612,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	lifecycle {
 		ignore_changes = [
 			"default_gateway",
-            "username",
-            "password",
+			"username",
+			"password",
 		]
 	}
 }`,

--- a/ecl/resource_ecl_vna_appliance_v1_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_test.go
@@ -501,6 +501,8 @@ func TestAccVNAV1Appliance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPtr("ecl_vna_appliance_v1.appliance_1", "interface_1_info.0.network_id", &n.ID),
 					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "interface_1_fixed_ips.0.ip_address", "192.168.1.50"),
 					resource.TestCheckResourceAttrPtr("ecl_vna_appliance_v1.appliance_1", "interface_1_fixed_ips.0.subnet_id", &sn.ID),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "initial_config.format", "set"),
+					resource.TestCheckResourceAttr("ecl_vna_appliance_v1.appliance_1", "initial_config.data", "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"),
 					testAccCheckVNAV1FixedIPLength(&vna, 1, 1),
 					testAccCheckVNAV1FixedIPLength(&vna, 2, 0),
 					testAccCheckVNAV1FixedIPLength(&vna, 3, 0),
@@ -798,6 +800,11 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	interface_1_fixed_ips {
 		ip_address = "192.168.1.50"
+	}
+
+	initial_config = {
+		"format" = "set"
+		"data" = "c2V0IGludGVyZmFjZXMgZ2UtMC8wLzAgZGVzY3JpcHRpb24gc2FtcGxl"
 	}
 
 	lifecycle {

--- a/ecl/resource_ecl_vna_appliance_v1_test.go
+++ b/ecl/resource_ecl_vna_appliance_v1_test.go
@@ -788,9 +788,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "v1"
-    }
+	tags = {
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -836,8 +836,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		"ecl_network_subnet_v2.subnet_8"
 	]
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	interface_3_info  {
 		name = "interface_3"
@@ -849,7 +849,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		ip_address = "192.168.3.50"
 	}
 
-    interface_8_info  {
+	interface_8_info  {
 		name = "interface_8"
 		description = "interface_8_description"
 		network_id = "${ecl_network_network_v2.network_8.id}"
@@ -881,8 +881,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	lifecycle {
 		ignore_changes = [
@@ -907,9 +907,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "v1"
-    }
+	tags = {
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -943,9 +943,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "v1"
-    }
+	tags = {
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -987,8 +987,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	]
 
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1000,15 +1000,15 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		ip_address = "192.168.1.50"
 	}
 
-    interface_2_info  {
+	interface_2_info  {
 		network_id = "${ecl_network_network_v2.network_2.id}"
 	}
 
-    interface_3_info  {
+	interface_3_info  {
 		network_id = "${ecl_network_network_v2.network_3.id}"
 	}
 
-    interface_3_fixed_ips {
+	interface_3_fixed_ips {
 		ip_address = "192.168.3.50"
 	}
 
@@ -1054,8 +1054,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	]
 
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1067,7 +1067,7 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 		ip_address = "192.168.1.50"
 	}
 
-    interface_2_info  {
+	interface_2_info  {
 		network_id = "${ecl_network_network_v2.network_2.id}"
 	}
 
@@ -1112,10 +1112,10 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%[2]s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "%[3]s"
-        k2 = "%[3]s"
-    }
+	tags = {
+		k1 = "%[3]s"
+		k2 = "%[3]s"
+	}
 
 	interface_1_info  {
 		name = "%[3]s"
@@ -1192,8 +1192,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1230,9 +1230,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "v1"
-    }
+	tags = {
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1275,9 +1275,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "v1"
-    }
+	tags = {
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1320,9 +1320,9 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	virtual_network_appliance_plan_id = "%s"
 
 	depends_on = ["ecl_network_subnet_v2.subnet_1"]
-    tags = {
-        k1 = "v1"
-    }
+	tags = {
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1366,8 +1366,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	]
 
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"
@@ -1414,8 +1414,8 @@ resource "ecl_vna_appliance_v1" "appliance_1" {
 	]
 
 	tags = {
-        k1 = "v1"
-    }
+		k1 = "v1"
+	}
 
 	interface_1_info  {
 		name = "interface_1"

--- a/ecl/vna.go
+++ b/ecl/vna.go
@@ -102,6 +102,16 @@ func getTagsAsOpts(rawTags map[string]interface{}) map[string]string {
 	return tags
 }
 
+func getInitialConfigCreateOpts(d *schema.ResourceData) *appliances.CreateOptsInitialConfig {
+	if _, ok := d.GetOk("initial_config"); ok {
+		return &appliances.CreateOptsInitialConfig{
+			Format: d.Get("initial_config.format").(string),
+			Data:   d.Get("initial_config.data").(string),
+		}
+	}
+	return nil
+}
+
 func getInterfaceCreateOpts(d *schema.ResourceData) *appliances.CreateOptsInterfaces {
 	var interfaces appliances.CreateOptsInterfaces
 	isInterfacesCreated := false

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nttcom/terraform-provider-ecl
 
 require (
 	github.com/hashicorp/terraform v0.12.6
-	github.com/nttcom/eclcloud/v3 v3.1.0
+	github.com/nttcom/eclcloud/v3 v3.2.0
 	github.com/unknwon/com v0.0.0-20190804042917-757f69c95f3e
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/nttcom/eclcloud/v3 v3.1.0 h1:9+qbyKrL/HhU06Whuj1BBXABGJbTHNwlNr22X5YbAmQ=
-github.com/nttcom/eclcloud/v3 v3.1.0/go.mod h1:dYmIyCIBYCdzQTo3ZAWq/q3LmmhGdUQv0xDuu8wa74Q=
+github.com/nttcom/eclcloud/v3 v3.2.0 h1:zAA2n/ecAhrG4rg412A63Wc1w/AJt5HS2+L5P0WQiys=
+github.com/nttcom/eclcloud/v3 v3.2.0/go.mod h1:dYmIyCIBYCdzQTo3ZAWq/q3LmmhGdUQv0xDuu8wa74Q=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/vendor/github.com/nttcom/eclcloud/v3/ecl/vna/v1/appliances/requests.go
+++ b/vendor/github.com/nttcom/eclcloud/v3/ecl/vna/v1/appliances/requests.go
@@ -94,16 +94,22 @@ type CreateOptsInterfaces struct {
 	Interface8 *CreateOptsInterface `json:"interface_8,omitempty"`
 }
 
+type CreateOptsInitialConfig struct {
+	Format string `json:"format" required:"true"`
+	Data   string `json:"data" required:"true"`
+}
+
 // CreateOpts represents options used to create a virtual network appliance.
 type CreateOpts struct {
-	Name                          string                `json:"name,omitempty"`
-	Description                   string                `json:"description,omitempty"`
-	DefaultGateway                string                `json:"default_gateway,omitempty"`
-	AvailabilityZone              string                `json:"availability_zone,omitempty"`
-	VirtualNetworkAppliancePlanID string                `json:"virtual_network_appliance_plan_id" required:"true"`
-	TenantID                      string                `json:"tenant_id,omitempty"`
-	Tags                          map[string]string     `json:"tags,omitempty"`
-	Interfaces                    *CreateOptsInterfaces `json:"interfaces,omitempty"`
+	Name                          string                   `json:"name,omitempty"`
+	Description                   string                   `json:"description,omitempty"`
+	DefaultGateway                string                   `json:"default_gateway,omitempty"`
+	AvailabilityZone              string                   `json:"availability_zone,omitempty"`
+	VirtualNetworkAppliancePlanID string                   `json:"virtual_network_appliance_plan_id" required:"true"`
+	TenantID                      string                   `json:"tenant_id,omitempty"`
+	Tags                          map[string]string        `json:"tags,omitempty"`
+	Interfaces                    *CreateOptsInterfaces    `json:"interfaces,omitempty"`
+	InitialConfig                 *CreateOptsInitialConfig `json:"initial_config,omitempty"`
 }
 
 // ToApplianceCreateMap builds a request body from CreateOpts.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -290,7 +290,7 @@ github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/nttcom/eclcloud/v3 v3.1.0
+# github.com/nttcom/eclcloud/v3 v3.2.0
 ## explicit; go 1.17
 github.com/nttcom/eclcloud/v3
 github.com/nttcom/eclcloud/v3/ecl

--- a/website/docs/r/vna_appliance_v1.html.markdown
+++ b/website/docs/r/vna_appliance_v1.html.markdown
@@ -278,6 +278,8 @@ The following arguments are supported:
 
 * `interface_[slot number]_no_allowed_address_pairs` (Optional) Set this true when you want to remove allowed address pairs from interface.
 
+* `initial_config` (Optional) Initial configuration of the Virtual Network Appliance.
+
 The `interface_[slot number]_info` block supports:
 
 * `name` - (Optional) Name of the interface.
@@ -308,6 +310,13 @@ The `interface_[slot number]_allowed_address_pairs` block supports:
 * `vrid` - (Required) VRID of allowed address pairs.
   Even though type of this parameter is integer in actual API specification, 
   You need to specify this argument by string, like, "null", "0", "255".
+
+The `initial_config` block supports:
+
+* `format` - (Required) Initial configuration format(set, text).
+
+* `data` - (Required) Initial configuration data.
+  data does not exceed 512KB in size before base64 encoding.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Changes
Follow-up on VNA/Initial Configuration Deployment Feature
(Aligned with https://github.com/nttcom/eclcloud/pull/51)

## Test
### UT(Mock)
```
➜  terraform-provider-ecl git:(john/VNF-3111_initial_config) ✗ make testacc-args TEST=./ecl TESTARGS="-run=^TestMockedAccVNAV1 -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ecl -v -run=^TestMockedAccVNAV1 -count=1 -timeout 120m
=== RUN   TestMockedAccVNAV1AppliancePlanDataSource_basic
--- PASS: TestMockedAccVNAV1AppliancePlanDataSource_basic (0.17s)
=== RUN   TestMockedAccVNAV1AppliancePlanDataSource_queries
--- PASS: TestMockedAccVNAV1AppliancePlanDataSource_queries (0.26s)
=== RUN   TestMockedAccVNAV1Appliance_updateMetaBasic
--- PASS: TestMockedAccVNAV1Appliance_updateMetaBasic (434.54s)
=== RUN   TestMockedAccVNAV1Appliance_updateAllowedAddressPairBasic
--- PASS: TestMockedAccVNAV1Appliance_updateAllowedAddressPairBasic (309.40s)
=== RUN   TestMockedAccVNAV1ApplianceUpdateFixedIP_basic
--- PASS: TestMockedAccVNAV1ApplianceUpdateFixedIP_basic (309.43s)
=== RUN   TestMockedAccVNAV1Appliance_createInterfaceDiscontinuity
--- PASS: TestMockedAccVNAV1Appliance_createInterfaceDiscontinuity (184.20s)
=== RUN   TestMockedAccVNAV1Appliance_createNoInterface
--- PASS: TestMockedAccVNAV1Appliance_createNoInterface (184.23s)
=== RUN   TestMockedAccVNAV1Appliance_createFixedIPsEmpty
--- PASS: TestMockedAccVNAV1Appliance_createFixedIPsEmpty (184.24s)
=== RUN   TestMockedAccVNAV1Appliance_createNoFixedIPs
--- PASS: TestMockedAccVNAV1Appliance_createNoFixedIPs (184.22s)
=== RUN   TestMockedAccVNAV1Appliance_basic
--- PASS: TestMockedAccVNAV1Appliance_basic (184.24s)
=== RUN   TestMockedAccVNAV1ApplianceSimple_basic
--- PASS: TestMockedAccVNAV1ApplianceSimple_basic (184.24s)
PASS
ok      github.com/nttcom/terraform-provider-ecl/ecl    2161.144s
```

### IT
```
➜  terraform-provider-ecl git:(john/VNF-3111_initial_config) ✗ TF_LOG=TRACE OS_DEBUG=1 make testacc-args TEST=./ecl TESTARGS="-run=TestAccVNAV1Appliance_basic -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ecl -v -run=TestAccVNAV1Appliance_basic -count=1 -timeout 120m
=== RUN   TestAccVNAV1Appliance_basic
…
--- PASS: TestAccVNAV1Appliance_basic (807.35s)
PASS
ok      github.com/nttcom/terraform-provider-ecl/ecl    809.303s
```

