### PR TITLE
fix: send nil for admin_state_up when unspecified in ecl_network_port_v2

### DIFF
--- a/ecl/resource_ecl_network_port_v2.go
+++ b/ecl/resource_ecl_network_port_v2.go
@@ -428,13 +428,11 @@ func resourceAllowedAddressPairsV2(d *schema.ResourceData) []ports.AddressPair {
 }
 
 func resourcePortAdminStateUpV2(d *schema.ResourceData) *bool {
-	value := false
-
-	if raw, ok := d.GetOk("admin_state_up"); ok && raw == true {
-		value = true
+	if v, ok := d.GetOkExists("admin_state_up"); ok {
+		asu := v.(bool)
+		return &asu
 	}
-
-	return &value
+	return nil
 }
 
 func resourcePortSecurityGroupsV2(d *schema.ResourceData) *[]string {

--- a/ecl/resource_ecl_network_port_v2_test.go
+++ b/ecl/resource_ecl_network_port_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/nttcom/eclcloud/v3/ecl/network/v2/networks"
@@ -1021,3 +1022,52 @@ resource "ecl_network_port_v2" "port_1" {
   }
 }
 `
+
+func TestResourceNetworkPortV2AdminStateUp_unspecified(t *testing.T) {
+	raw := map[string]interface{}{
+		"network_id": "test-network-id",
+	}
+	d := schema.TestResourceDataRaw(t, resourceNetworkPortV2().Schema, raw)
+
+	result := resourcePortAdminStateUpV2(d)
+
+	// admin_state_up が未指定のとき、API に値を送信しないよう nil を返すべき。
+	// サーバーデフォルトは true であり、false を送ると意図せずポートがダウン状態になる。
+	if result != nil {
+		t.Fatalf("expected nil when admin_state_up is unspecified, got: %v", *result)
+	}
+}
+
+func TestResourceNetworkPortV2AdminStateUp_true(t *testing.T) {
+	raw := map[string]interface{}{
+		"network_id":     "test-network-id",
+		"admin_state_up": true,
+	}
+	d := schema.TestResourceDataRaw(t, resourceNetworkPortV2().Schema, raw)
+
+	result := resourcePortAdminStateUpV2(d)
+
+	if result == nil {
+		t.Fatal("expected non-nil when admin_state_up=true")
+	}
+	if *result != true {
+		t.Fatalf("expected true, got: %v", *result)
+	}
+}
+
+func TestResourceNetworkPortV2AdminStateUp_false(t *testing.T) {
+	raw := map[string]interface{}{
+		"network_id":     "test-network-id",
+		"admin_state_up": false,
+	}
+	d := schema.TestResourceDataRaw(t, resourceNetworkPortV2().Schema, raw)
+
+	result := resourcePortAdminStateUpV2(d)
+
+	if result == nil {
+		t.Fatal("expected non-nil when admin_state_up=false")
+	}
+	if *result != false {
+		t.Fatalf("expected false, got: %v", *result)
+	}
+}


### PR DESCRIPTION
resourcePortAdminStateUpV2 was always returning a non-nil *bool(false), causing "admin_state_up": false to be sent to the API even when the user omitted the field. This bypassed the server-side default of true, leaving ports in an administratively down state unexpectedly.

Fix by using GetOkExists so that nil is returned when the field is not set, allowing eclcloud's omitempty to suppress the field and let the server apply its default (true). This aligns with the pattern already used by ecl_network_network_v2.